### PR TITLE
Fix build by avoiding building modules that require node.js

### DIFF
--- a/rpm/build.sh
+++ b/rpm/build.sh
@@ -7,9 +7,11 @@ if [[ "X$HADOOP_VERSION" = "X" ]]; then
     exit 1
 fi
 
-if [[ "X$MAVEN_DIR" != "X" ]]; then
-    export PATH="$PATH:$MAVEN_DIR/bin"
+if [[ "X$MAVEN_DIR" = "X" ]]; then
+    MAVEN_DIR="/opt/build-deps/maven3/bin/mvn"
 fi
+
+export PATH="$PATH:$MAVEN_DIR/bin"
 
 RPM_DIR="$TEMP_OUTPUT_DIR"
 

--- a/rpm/sources/do-component-build
+++ b/rpm/sources/do-component-build
@@ -24,8 +24,16 @@ MAVEN_OPTS+="-Drequire.zstd -Dbundle.zstd -Dzstd.lib=/usr/lib64 "
 MAVEN_OPTS+="-Drequire.snappy -Dbundle.snappy=true -Dsnappy.lib=/usr/lib64 "
 MAVEN_OPTS+="-Drequire.openssl "
 
+# The Yarn UI and the yarn applications catalog both require a version of node.js which does not work with centos6
+# I've removed -Pyarn-ui, and added the below -pl exclusion in order to get around this incompatibility.
+# If we end up needing yarn-ui as part of a yarn upgrade, we'll need to investigate building this for centos8 or some
+# other more tactical workaround like pinning the node.js to an older version. I tried that with -Dnodejs.version, but that
+# failed for other dependencies that expected a particular node version, etc. So a deeper investigation will be necessary.
+
 # Build artifacts
-mvn $ANT_OPTS $BUNDLE_SNAPPY -Pdist -Pnative -Pyarn-ui -Dtar ${MAVEN_OPTS} clean package ${EXTRA_GOALS} "$@"
+mvn $ANT_OPTS $BUNDLE_SNAPPY \
+    -pl '!hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-webapp' \
+    -Pdist -Pnative -Dtar ${MAVEN_OPTS} clean package ${EXTRA_GOALS} "$@"
 
 (cd build ; tar --strip-components=1 -xzvf  ../hadoop-dist/target/hadoop-${HADOOP_VERSION}.tar.gz)
 


### PR DESCRIPTION
We started having build failures recently, with a error message like this:

```
[INFO] Running 'yarn ' in /temporary_artifacts/scratch/BUILD/hadoop-3.3.1-src/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-webapp/target
[INFO] yarn install v1.7.0
[INFO] info No lockfile found.
[INFO] [1/4] Resolving packages...
[INFO] [2/4] Fetching packages...
[INFO] error safe-stable-stringify@2.3.1: The engine "node" is incompatible with this module. Expected version ">=10".
[INFO] error safe-stable-stringify@2.3.1: The engine "node" is incompatible with this module. Expected version ">=10".info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
[INFO] error Found incompatible module
```

I tried backporting a couple upstream jiras, but that only changed the error:

```
[INFO] Running 'yarn ' in /temporary_artifacts/scratch/BUILD/hadoop-3.3.1-src/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-webapp/target
[INFO] node: /usr/lib64/libstdc++.so.6: version `GLIBCXX_3.4.14' not found (required by node)
[INFO] node: /usr/lib64/libstdc++.so.6: version `GLIBCXX_3.4.18' not found (required by node)
[INFO] node: /usr/lib64/libstdc++.so.6: version `CXXABI_1.3.5' not found (required by node)
[INFO] node: /usr/lib64/libstdc++.so.6: version `GLIBCXX_3.4.15' not found (required by node)
[INFO] node: /lib64/libc.so.6: version `GLIBC_2.16' not found (required by node)
[INFO] node: /lib64/libc.so.6: version `GLIBC_2.17' not found (required by node)
[INFO] node: /lib64/libc.so.6: version `GLIBC_2.14' not found (required by node)
```

Digging into it further I believe this is because this module does not specify a yarn.lock file, so as new versions of the dependencies are released we may be picking them up. In this case it was initially a release of safe-stable-stringify, upon other iterations it was a release of `winston`. Both of these cases required a later version of node.js, and later versions of node.js require a newer version of glibc than we have access to in our environment.

We don't currently deploy yarn-ui from this build, and I dont think we have any use-case for this hadoop-yarn-applications-catalog. Ideally we could slim down our build, but now we depend on -Pdist. So I've opted to simply disable these two modules, which gets the build to succeed. 