### PR TITLE
Give hadoop-rpm a name in Blazar

### DIFF
--- a/rpm/.blazar.yaml
+++ b/rpm/.blazar.yaml
@@ -6,6 +6,9 @@ buildpack:
   repository: rpm_builders
   branch: master
 
+provides:
+  - name: hadoop-rpm
+
 depends:
   - name: apache-hadoop-build-container
 


### PR DESCRIPTION
Giving this module a name in Blazar will allow us to automatically trigger downstream Docker image builds