### PR TITLE
Save build time by not generating Javadocs

### DIFF
--- a/rpm/sources/do-component-build
+++ b/rpm/sources/do-component-build
@@ -19,7 +19,7 @@ set -ex
 mkdir -p build
  
 # Build artifacts
-MAVEN_OPTS+="-DskipTests -DskipTest -DskipITs "
+MAVEN_OPTS+="-DskipTests -DskipTest -DskipITs -Dmaven.javadoc.skip=true "
 MAVEN_OPTS+="-Drequire.zstd -Dbundle.zstd -Dzstd.lib=/usr/lib64 "
 MAVEN_OPTS+="-Drequire.snappy -Dbundle.snappy=true -Dsnappy.lib=/usr/lib64 "
 MAVEN_OPTS+="-Drequire.openssl "


### PR DESCRIPTION
This takes 3-4 minutes off the build time