### PR TITLE
HADOOP-17869. `fs.s3a.connection.maximum` should be bigger than `fs.s…

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
+++ b/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
@@ -1339,7 +1339,7 @@
 
 <property>
   <name>fs.s3a.connection.maximum</name>
-  <value>48</value>
+  <value>96</value>
   <description>Controls the maximum number of simultaneous connections to S3.
     This must be bigger than the value of fs.s3a.threads.max so as to stop
     threads being blocked waiting for new HTTPS connections.

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -147,7 +147,7 @@ public final class Constants {
 
   // number of simultaneous connections to s3
   public static final String MAXIMUM_CONNECTIONS = "fs.s3a.connection.maximum";
-  public static final int DEFAULT_MAXIMUM_CONNECTIONS = 48;
+  public static final int DEFAULT_MAXIMUM_CONNECTIONS = 96;
 
   // connect to s3 over ssl?
   public static final String SECURE_CONNECTIONS =


### PR DESCRIPTION
…3a.threads.max` (#3337).

The value of `fs.s3a.connection.maximum` has been increased to 96

Contributed by Dongjoon Hyun

