### PR TITLE
Tweak how YUM repo is specified

### DIFF
--- a/rpm/.blazar.yaml
+++ b/rpm/.blazar.yaml
@@ -20,13 +20,28 @@ env:
   ENABLE_CENTOS_8_RPMS: "true"
 
   # This will be updated automatically by the "Set yum repo and package version" step below
-  YUM_REPO_UPLOAD_OVERRIDE: "UPDATE ME"
+  MAIN_YUM_REPO: "8_hs-hadoop"
+  DEVELOP_YUM_REPO: "8_hs-hadoop-develop"
+  YUM_REPO_UPLOAD_OVERRIDE_CENTOS_8: "UPDATE ME"
 
   # The entry point script for the rpm build
   RPM_BUILD_COMMAND: "./build.sh"
   BUILD_CONTAINER_IMAGE_CENTOS_8: "docker.hubteam.com/apache-hadoop-build-container/apache-hadoop-build-container:latest"
   CONTAINER_TEMP_OUTPUT_DIR: /temporary_artifacts
   CONTAINER_RPMS_OUTPUT_DIR: /generated_rpms
+
+before:
+  - description: Set yum repo
+    commands:
+      - |
+          if [ "$GIT_BRANCH" = "$MAIN_BRANCH" ]; then
+            repo=$MAIN_YUM_REPO
+          else
+            repo=$DEVELOP_YUM_REPO
+          fi
+          # exports in this rc file are available in all steps
+          echo "export YUM_REPO_UPLOAD_OVERRIDE_CENTOS_8=$repo" >> $BUILD_COMMAND_RC_FILE
+          echo "Will upload package to $repo"
 
 buildResources:
   cpus: 8

--- a/rpm/build.sh
+++ b/rpm/build.sh
@@ -21,19 +21,12 @@ MAIN_BRANCH="hubspot-3.3"
 # We want our resulting version to follow this schema:
 # master branch: {hadoop_version}-hs.{build_number}.el8
 # other branches: {hadoop_version}-hs~{branch_name}.{build_number}.el8, where branch_name substitutes underscore for non-alpha-numeric characters
-MAIN_YUM_REPO="8_hs-hadoop"
-DEVELOP_YUM_REPO="8_hs-hadoop-develop"
 release_prefix="hs"
-if [ "$GIT_BRANCH" = "$MAIN_BRANCH" ]; then
-    repo=$MAIN_YUM_REPO
-else
+if [ "$GIT_BRANCH" != "$MAIN_BRANCH" ]; then
     release_prefix="${release_prefix}~${GIT_BRANCH//[^[:alnum:]]/_}"
-    repo=$DEVELOP_YUM_REPO
 fi
 release="${release_prefix}.${BUILD_NUMBER}"
 export PKG_RELEASE=$release
-export YUM_REPO_UPLOAD_OVERRIDE=$repo
-echo "Will upload package with release $release to $repo"
 
 export PATH="$PATH:$MAVEN_DIR/bin"
 


### PR DESCRIPTION
I made a mistake in my previous PR. We need the proper repo name available to the buildpack in the variable `YUM_REPO_UPLOAD_OVERRIDE_CENTOS_8` in order to get our RPMs into the desired repo.