### PR TITLE
Fix where MAIN_BRANCH env var is defined

### DIFF
--- a/rpm/.blazar.yaml
+++ b/rpm/.blazar.yaml
@@ -19,9 +19,10 @@ env:
   DISABLE_CENTOS_6_RPMS: "true"
   ENABLE_CENTOS_8_RPMS: "true"
 
-  # This will be updated automatically by the "Set yum repo and package version" step below
+  MAIN_BRANCH: "hubspot-3.3"
   MAIN_YUM_REPO: "8_hs-hadoop"
   DEVELOP_YUM_REPO: "8_hs-hadoop-develop"
+  # This will be updated automatically by the "Set yum repo and package version" step below
   YUM_REPO_UPLOAD_OVERRIDE_CENTOS_8: "UPDATE ME"
 
   # The entry point script for the rpm build


### PR DESCRIPTION
Another little mistake of mine that was causing RPMs to go to the wrong repo