### PR TITLE
Replace shaded AWS SDK dependency with specific dependencies

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -973,9 +973,12 @@
           </exclusion>
         </exclusions>
       </dependency>
+      <!--
+      Replaced AWS SDK dependencies for the hadoop-aws artifact.
+      -->
       <dependency>
         <groupId>com.amazonaws</groupId>
-        <artifactId>aws-java-sdk-bundle</artifactId>
+        <artifactId>aws-java-sdk-dynamodb</artifactId>
         <version>${aws-java-sdk.version}</version>
         <exclusions>
           <exclusion>
@@ -984,6 +987,31 @@
           </exclusion>
         </exclusions>
       </dependency>
+      <dependency>
+        <groupId>com.amazonaws</groupId>
+        <artifactId>aws-java-sdk-s3</artifactId>
+        <version>${aws-java-sdk.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>io.netty</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>com.amazonaws</groupId>
+        <artifactId>aws-java-sdk-sts</artifactId>
+        <version>${aws-java-sdk.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>io.netty</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <!--
+      End of replaced dependencies.
+      -->
       <dependency>
         <groupId>org.apache.mina</groupId>
         <artifactId>mina-core</artifactId>

--- a/hadoop-tools/hadoop-aws/pom.xml
+++ b/hadoop-tools/hadoop-aws/pom.xml
@@ -481,11 +481,27 @@
       <scope>test</scope>
       <type>test-jar</type>
     </dependency>
+    <!--
+    The following replace the AWS JDK bundle with specific dependencies.
+    -->
     <dependency>
       <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk-bundle</artifactId>
+      <artifactId>aws-java-sdk-dynamodb</artifactId>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-s3</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-sts</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <!--
+    End of replaced dependencies
+    -->
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/ConfigureShadedAWSSocketFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/ConfigureShadedAWSSocketFactory.java
@@ -22,7 +22,7 @@ import javax.net.ssl.HostnameVerifier;
 import java.io.IOException;
 
 import com.amazonaws.ClientConfiguration;
-import com.amazonaws.thirdparty.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 
 import org.apache.hadoop.security.ssl.DelegatingSSLSocketFactory;
 


### PR DESCRIPTION
## Goal
Reduce the dependency footprint by replacing the shaded AWS SDK dependency with the specific dependencies actually required.

## Context
The shaded bundle AWS SDK dependency is very large and is not required. Rather than externally manipulate the dependencies, we're changing then by patching our fork. Sadly, it wasn't possible to constrain the changes to the POMs only. A code change was necessary because the shaded AWS SDK uses a bundled version of Apache `httpcomponent` which renames the package for the `SSLConnectionSocketFactory` class. The non-shaded version doesn't do this.

The rest of the reflection protection logic probably isn't necessary as its intended for cases where the bundled version is externally excluded and then replaced with the specific versions, but rather than doing anything more invasive here, the minimal package name change is made. This allows for building.