### PR TITLE
Publish modules into our Maven repo

### DIFF
--- a/.blazar.yaml
+++ b/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/build-scripts/copy_blazar_yaml.sh
+++ b/build-scripts/copy_blazar_yaml.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+poms=$(find . -name pom.xml)
+
+for pom in $poms; do
+    module=$(dirname $pom)
+    if [[ "$module" != "." ]]; then
+        cp .blazar.yaml $module/.blazar.yaml
+    fi
+done

--- a/build-scripts/prepare_environment.sh
+++ b/build-scripts/prepare_environment.sh
@@ -1,0 +1,90 @@
+#
+# Generates the appropriate environment vars so that we:
+# - build against the right version of hadoop, and properly set up maven
+# - generate the correct maven version based on the branches
+# - upload RPMs with the correct release based on the branch, and to the right yum repo
+#
+# Since we need to distribute .blazar.yaml to all sub-modules of the project, we define our constants once
+# in this script which can be re-used by every .blazar.yaml.
+#
+set -ex
+printenv
+
+# We base the expected main branch and resulting maven version for clients on the hadoop minor version
+# The reason for this is hadoop re-branches for each minor release (2.4, 2.5, 2.6, etc). At each re-branch
+# the histories diverge. So we'll need to create our own fork of each new minor release branch.
+# The convention is a fork named "hubspot-$minorVersion", and the maven coordinates "$minorVersion-hubspot-SNAPSHOT"
+MINOR_VERSION="3.3"
+MAIN_BRANCH="hubspot-${MINOR_VERSION}"
+
+# If we bump our hadoop build version, we should bump this as well
+# At some point it would be good to more closely link this to our hadoop build, but that can only happen
+# once we update our apache-hadoop build to do a full maven. At which point we can probably change this to
+# like 3.0-hubspot-SNAPSHOT and leave it at that.
+MAVEN_ARGS="$VERSION_ARGS -Dgpg.skip=true -DskipTests=true"
+
+#
+# Validate inputs from blazar
+#
+
+if [ -z "$WORKSPACE" ]; then
+    echo "Missing env var \$WORKSPACE"
+    exit 1
+fi
+if [ -z "$GIT_BRANCH" ]; then
+    echo "Missing env var \$GIT_BRANCH"
+    exit 1
+fi
+if [ -z "$BUILD_COMMAND_RC_FILE" ]; then
+    echo "Missing env var \$BUILD_COMMAND_RC_FILE"
+    exit 1
+fi
+
+#
+# Extract current hadoop version from root pom.xml
+#
+
+HADOOP_VERSION=$(echo "cat /project/version/text()" | xmllint --nocdata --shell $WORKSPACE/pom.xml | sed '1d;$d')
+
+# Generate branch-specific env vars
+# We are going to generate the maven version and the RPM release here:
+# - For the maven version, we need to special case our main branch
+# - For RPM, we want our final version to be:
+#   main branch: {hadoop_version}-hs.{build_number}.el8
+#   other branches: {hadoop_version}-hs~{branch_name}.{build_number}.el8, where branch_name substitutes underscore for non-alpha-numeric characters
+#
+
+echo "Git branch $GIT_BRANCH. Detecting appropriate version override and RPM release."
+
+RELEASE="hs"
+
+if [[ "$GIT_BRANCH" = "$MAIN_BRANCH" ]]; then
+    MAVEN_VERSION="${MINOR_VERSION}-hubspot-SNAPSHOT"
+elif [[ "$GIT_BRANCH" != "hubspot" ]]; then
+    MAVEN_VERSION="${MINOR_VERSION}-${GIT_BRANCH}-SNAPSHOT"
+    RELEASE="${RELEASE}~${GIT_BRANCH//[^[:alnum:]]/_}"
+else
+    echo "Invalid git branch $GIT_BRANCH"
+    exit 1
+fi
+
+RELEASE="${RELEASE}.${BUILD_NUMBER}"
+FULL_BUILD_VERSION="${HADOOP_VERSION}-${RELEASE}"
+
+MAVEN_ARGS="$MAVEN_ARGS -Dhadoop.version=$MAVEN_VERSION"
+
+#
+# Dump generated env vars into rc file
+#
+
+cat >> "$BUILD_COMMAND_RC_FILE" <<EOF
+export MAVEN_ARGS='$MAVEN_ARGS'
+export SET_VERSION='$MAVEN_VERSION'
+export HADOOP_VERSION='HADOOP_VERSION'
+export PKG_RELEASE='$RELEASE'
+export FULL_BUILD_VERSION='$FULL_BUILD_VERSION'
+EOF
+
+echo "Building Hadoop version $HADOOP_VERSION"
+echo "Will use maven version $MAVEN_VERSION"
+echo "Will run maven with extra args $MAVEN_ARGS"

--- a/hadoop-assemblies/.blazar.yaml
+++ b/hadoop-assemblies/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-build-tools/.blazar.yaml
+++ b/hadoop-build-tools/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-client-modules/.blazar.yaml
+++ b/hadoop-client-modules/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-client-modules/hadoop-client-api/.blazar.yaml
+++ b/hadoop-client-modules/hadoop-client-api/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-client-modules/hadoop-client-check-invariants/.blazar.yaml
+++ b/hadoop-client-modules/hadoop-client-check-invariants/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-client-modules/hadoop-client-check-test-invariants/.blazar.yaml
+++ b/hadoop-client-modules/hadoop-client-check-test-invariants/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-client-modules/hadoop-client-integration-tests/.blazar.yaml
+++ b/hadoop-client-modules/hadoop-client-integration-tests/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-client-modules/hadoop-client-minicluster/.blazar.yaml
+++ b/hadoop-client-modules/hadoop-client-minicluster/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-client-modules/hadoop-client-runtime/.blazar.yaml
+++ b/hadoop-client-modules/hadoop-client-runtime/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-client-modules/hadoop-client/.blazar.yaml
+++ b/hadoop-client-modules/hadoop-client/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-cloud-storage-project/.blazar.yaml
+++ b/hadoop-cloud-storage-project/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-cloud-storage-project/hadoop-cloud-storage/.blazar.yaml
+++ b/hadoop-cloud-storage-project/hadoop-cloud-storage/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-cloud-storage-project/hadoop-cos/.blazar.yaml
+++ b/hadoop-cloud-storage-project/hadoop-cos/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-common-project/.blazar.yaml
+++ b/hadoop-common-project/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-common-project/hadoop-annotations/.blazar.yaml
+++ b/hadoop-common-project/hadoop-annotations/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-common-project/hadoop-auth-examples/.blazar.yaml
+++ b/hadoop-common-project/hadoop-auth-examples/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-common-project/hadoop-auth/.blazar.yaml
+++ b/hadoop-common-project/hadoop-auth/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-common-project/hadoop-common/.blazar.yaml
+++ b/hadoop-common-project/hadoop-common/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-common-project/hadoop-kms/.blazar.yaml
+++ b/hadoop-common-project/hadoop-kms/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-common-project/hadoop-minikdc/.blazar.yaml
+++ b/hadoop-common-project/hadoop-minikdc/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-common-project/hadoop-nfs/.blazar.yaml
+++ b/hadoop-common-project/hadoop-nfs/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-common-project/hadoop-registry/.blazar.yaml
+++ b/hadoop-common-project/hadoop-registry/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-dist/.blazar.yaml
+++ b/hadoop-dist/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-hdfs-project/.blazar.yaml
+++ b/hadoop-hdfs-project/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-hdfs-project/hadoop-hdfs-client/.blazar.yaml
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/.blazar.yaml
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/.blazar.yaml
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-hdfs-project/hadoop-hdfs-nfs/.blazar.yaml
+++ b/hadoop-hdfs-project/hadoop-hdfs-nfs/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/.blazar.yaml
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-hdfs-project/hadoop-hdfs/.blazar.yaml
+++ b/hadoop-hdfs-project/hadoop-hdfs/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-mapreduce-project/.blazar.yaml
+++ b/hadoop-mapreduce-project/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/.blazar.yaml
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/.blazar.yaml
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-common/.blazar.yaml
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-common/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/.blazar.yaml
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs-plugins/.blazar.yaml
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs-plugins/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/.blazar.yaml
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/.blazar.yaml
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/.blazar.yaml
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-shuffle/.blazar.yaml
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-shuffle/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-uploader/.blazar.yaml
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-uploader/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-mapreduce-project/hadoop-mapreduce-examples/.blazar.yaml
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-examples/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-maven-plugins/.blazar.yaml
+++ b/hadoop-maven-plugins/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-minicluster/.blazar.yaml
+++ b/hadoop-minicluster/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-project-dist/.blazar.yaml
+++ b/hadoop-project-dist/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-project/.blazar.yaml
+++ b/hadoop-project/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-tools/.blazar.yaml
+++ b/hadoop-tools/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-tools/hadoop-aliyun/.blazar.yaml
+++ b/hadoop-tools/hadoop-aliyun/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-tools/hadoop-archive-logs/.blazar.yaml
+++ b/hadoop-tools/hadoop-archive-logs/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-tools/hadoop-archives/.blazar.yaml
+++ b/hadoop-tools/hadoop-archives/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-tools/hadoop-aws/.blazar.yaml
+++ b/hadoop-tools/hadoop-aws/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-tools/hadoop-azure-datalake/.blazar.yaml
+++ b/hadoop-tools/hadoop-azure-datalake/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-tools/hadoop-azure/.blazar.yaml
+++ b/hadoop-tools/hadoop-azure/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-tools/hadoop-datajoin/.blazar.yaml
+++ b/hadoop-tools/hadoop-datajoin/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-tools/hadoop-distcp/.blazar.yaml
+++ b/hadoop-tools/hadoop-distcp/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-tools/hadoop-dynamometer/.blazar.yaml
+++ b/hadoop-tools/hadoop-dynamometer/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-tools/hadoop-dynamometer/hadoop-dynamometer-blockgen/.blazar.yaml
+++ b/hadoop-tools/hadoop-dynamometer/hadoop-dynamometer-blockgen/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-tools/hadoop-dynamometer/hadoop-dynamometer-dist/.blazar.yaml
+++ b/hadoop-tools/hadoop-dynamometer/hadoop-dynamometer-dist/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-tools/hadoop-dynamometer/hadoop-dynamometer-infra/.blazar.yaml
+++ b/hadoop-tools/hadoop-dynamometer/hadoop-dynamometer-infra/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-tools/hadoop-dynamometer/hadoop-dynamometer-workload/.blazar.yaml
+++ b/hadoop-tools/hadoop-dynamometer/hadoop-dynamometer-workload/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-tools/hadoop-extras/.blazar.yaml
+++ b/hadoop-tools/hadoop-extras/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-tools/hadoop-fs2img/.blazar.yaml
+++ b/hadoop-tools/hadoop-fs2img/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-tools/hadoop-gridmix/.blazar.yaml
+++ b/hadoop-tools/hadoop-gridmix/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-tools/hadoop-kafka/.blazar.yaml
+++ b/hadoop-tools/hadoop-kafka/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-tools/hadoop-openstack/.blazar.yaml
+++ b/hadoop-tools/hadoop-openstack/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-tools/hadoop-pipes/.blazar.yaml
+++ b/hadoop-tools/hadoop-pipes/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-tools/hadoop-resourceestimator/.blazar.yaml
+++ b/hadoop-tools/hadoop-resourceestimator/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-tools/hadoop-rumen/.blazar.yaml
+++ b/hadoop-tools/hadoop-rumen/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-tools/hadoop-sls/.blazar.yaml
+++ b/hadoop-tools/hadoop-sls/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-tools/hadoop-streaming/.blazar.yaml
+++ b/hadoop-tools/hadoop-streaming/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-tools/hadoop-tools-dist/.blazar.yaml
+++ b/hadoop-tools/hadoop-tools-dist/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-yarn-project/.blazar.yaml
+++ b/hadoop-yarn-project/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-yarn-project/hadoop-yarn/.blazar.yaml
+++ b/hadoop-yarn-project/hadoop-yarn/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/.blazar.yaml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/.blazar.yaml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/.blazar.yaml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-docker/.blazar.yaml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-docker/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-webapp/.blazar.yaml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-webapp/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-distributedshell/.blazar.yaml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-distributedshell/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-mawo/.blazar.yaml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-mawo/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-mawo/hadoop-yarn-applications-mawo-core/.blazar.yaml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-mawo/hadoop-yarn-applications-mawo-core/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-unmanaged-am-launcher/.blazar.yaml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-unmanaged-am-launcher/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/.blazar.yaml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-api/.blazar.yaml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-api/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/.blazar.yaml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/.blazar.yaml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/.blazar.yaml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-csi/.blazar.yaml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-csi/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-registry/.blazar.yaml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-registry/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/.blazar.yaml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/.blazar.yaml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/.blazar.yaml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/.blazar.yaml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/.blazar.yaml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/.blazar.yaml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-sharedcachemanager/.blazar.yaml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-sharedcachemanager/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-tests/.blazar.yaml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-tests/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timeline-pluginstorage/.blazar.yaml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timeline-pluginstorage/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-documentstore/.blazar.yaml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-documentstore/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase-tests/.blazar.yaml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase-tests/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/.blazar.yaml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-client/.blazar.yaml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-client/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-common/.blazar.yaml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-common/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-server/.blazar.yaml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-server/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-server/hadoop-yarn-server-timelineservice-hbase-server-1/.blazar.yaml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-server/hadoop-yarn-server-timelineservice-hbase-server-1/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-server/hadoop-yarn-server-timelineservice-hbase-server-2/.blazar.yaml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-server/hadoop-yarn-server-timelineservice-hbase-server-2/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice/.blazar.yaml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/.blazar.yaml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-site/.blazar.yaml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-site/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/.blazar.yaml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh


### PR DESCRIPTION
For your consideration for our Monday meeting. I'm not in a rush. This PR adds the required files to build this repo and publish it as normal Maven modules. This then allows all the downstream users of Hadoop 3 libraries to use our builds, instead of the ones from Apache. Before this PR, our builds of this repo went into RPMs, but were not consumable via Maven.

My motivation here is that we will need to make edits to this repo in order to support SSL HDFS connections, and we need those edits to flow into downstream apps. See also https://github.com/HubSpot/hadoop/pull/14