### PR TITLE
Allow BasicInetPeer to work with BlockReaderRemote, and other SSL support

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/net/HubSpotHdfsSslUtils.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/net/HubSpotHdfsSslUtils.java
@@ -1,0 +1,55 @@
+package org.apache.hadoop.net;
+
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.SocketAddress;
+
+import javax.net.ssl.SSLSocket;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+public class HubSpotHdfsSslUtils {
+
+  public static final Log LOG = LogFactory.getLog(HubSpotHdfsSslUtils.class);
+
+  public static SocketAddress sslAddr(SocketAddress addr, Socket socket) {
+    try {
+      // We want to use the SSL port for our Hadoop services when:
+      //  1. The socket factory specified by hadoop.rpc.socket.factory.class.* produced an SSL socket
+      //  2. The address we're using is an InetSocketAddress, so it actually has a port. This should always be true.
+      // See NetUtils#getDefaultSocketFactory() for code that collaborates with this.
+      if (socket instanceof SSLSocket &&
+          addr instanceof InetSocketAddress) {
+        InetSocketAddress inetAddr = (InetSocketAddress) addr;
+        int port = inetAddr.getPort();
+        int newPort = translatePort(port);
+        if (newPort != port) {
+          InetSocketAddress newAddr = new InetSocketAddress(inetAddr.getHostString(), newPort);
+          LOG.debug("Converted " + inetAddr + " to " + newAddr);
+          return newAddr;
+        }
+      }
+    } catch (Exception e) {
+      LOG.warn("Unable to switch to SSL port for " + addr, e);
+    }
+    return addr;
+  }
+
+  private static int translatePort(int port) {
+    // port mapping matches haproxy.pp in puppet-deploy
+    if (port == 50010) {  // DataNode transfer
+      return 50011;
+    } else if (port == 50020) {  // DataNode IPC
+      return 50021;
+    } else if (port == 8020) {  // NameNode
+      return 8017;
+    } else if (port == 8021) {  // JobTracker
+      return 8023;
+    } else if (port == 8022) {  // JobTracker HA
+      return 8024;
+    } else {
+      return port;
+    }
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/NameNodeProxiesClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/NameNodeProxiesClient.java
@@ -364,7 +364,7 @@ public class NameNodeProxiesClient {
     final long version = RPC.getProtocolVersion(ClientNamenodeProtocolPB.class);
     ClientNamenodeProtocolPB proxy = RPC.getProtocolProxy(
         ClientNamenodeProtocolPB.class, version, address, ugi, conf,
-        NetUtils.getDefaultSocketFactory(conf),
+        NetUtils.getSocketFactory(conf, ClientProtocol.class),
         org.apache.hadoop.ipc.Client.getTimeout(conf), defaultPolicy,
         fallbackToSimpleAuth, alignmentContext).getProxy();
 

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/net/BasicInetPeer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/net/BasicInetPeer.java
@@ -22,6 +22,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.Socket;
 import java.net.SocketAddress;
+import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
 
 import org.apache.hadoop.net.unix.DomainSocket;
@@ -46,10 +47,10 @@ public class BasicInetPeer implements Peer {
 
   @Override
   public ReadableByteChannel getInputStreamChannel() {
-    /*
-     * This Socket has no channel, so there's nothing to return here.
-     */
-    return null;
+    // HubSpot modification: provide a Channel so that BlockReaderRemote can use BasicInetPeer. The underlying socket
+    // is often an SSLSocket, which does not offer a Channel, so we cannot use NioInetPeer. If you want to use
+    // NioInetPeer with SSL, you need to provide a selectable Channel that handles SSL transparently, not an easy task.
+    return Channels.newChannel(in);
   }
 
   @Override


### PR DESCRIPTION
For your consideration at our Monday meeting.

This permits users of the HDFS libraries defined here to connect to HDFS over sockets that are instances of `SSLSocket`.
- In a variety of places in the HDFS client code, it does one thing if your `Socket` implements `getChannel()` and another thing if not. Plain `Socket`s do implement it, but `SSLSocket`s do not. Generally, this is well handled.
- All HDFS block reads are performed by `BlockReaderRemote`. This assumes your `Peer` object representing a DataNode provides a `ReadableByteChannel`. If your `Socket` does not offer a channel, then your `Peer` will be an instance of `BasicInetPeer`, which is for pre-NIO stuff that doesn't do channels, but then `BlockReaderRemote` still wants a channel from it. This seems honestly like a weird oversight from the Hadoop developers, because I don't see the point in having `BasicInetPeer` if it's not legitimately usable.
- This PR allows `BasicInetPeer` to provide a `ReadableByteChannel` by simply wrapping the `InputStream` from its `Socket`. Note that if the underlying `Socket` actually implements `getChannel()`, `BasicInetPeer` won't be used at all, instead `NioInetPeer` will be used. This means that when not using SSL for intra-cluster communications, backups, etc, we still get the performance benefits of async IO.

Additionally, this PR contains a variety of small configuration-type tweaks that are mostly taken from our Hadoop 2 fork
- `HubSpotHdfsSslUtils` makes you use the SSL port when you have an SSL connection
- Changes in `NetUtils` give you an `SSLSocket` when you want one, and let you pass a `Configuration` to it. The latter bit is new and is something that will come in handy when we do per-cluster certs.
- Changes to some NameNode connection stuff help us specify that we want to use SSL for HDFS connections but not YARN connections. This is another thing that seems like it really ought to be done already by the core devs.