### PR TITLE
Build with less memory

### DIFF
--- a/rpm/rpm-amd64/.blazar.yaml
+++ b/rpm/rpm-amd64/.blazar.yaml
@@ -44,7 +44,7 @@ before:
 
 buildResources:
   cpus: 8
-  memoryMb: 20480
+  memoryMb: 16384
 
 stepActivation:
   uploadRpms:

--- a/rpm/rpm-arm64/.blazar.yaml
+++ b/rpm/rpm-arm64/.blazar.yaml
@@ -46,7 +46,7 @@ before:
 
 buildResources:
   cpus: 8
-  memoryMb: 20480
+  memoryMb: 16384
 
 stepActivation:
   uploadRpms:


### PR DESCRIPTION
Pick a memory size that fits into the instances used in our build system better