### PR TITLE
Add a migration mode for block access tokens

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
@@ -1605,6 +1605,10 @@ public class DataNode extends ReconfigurableBase
   private synchronized void registerBlockPoolWithSecretManager(
       DatanodeRegistration bpRegistration, String blockPoolId) throws IOException {
     ExportedBlockKeys keys = bpRegistration.getExportedKeys();
+    if (getConf().getBoolean("dfs.block.access.token.migration.enabled", false)) {
+      LOG.info("Block access token migration enabled - ignoring blockTokenEnabled={} value from NameNode", keys.isBlockTokenEnabled());
+      return;
+    }
     if (!hasAnyBlockPoolRegistered) {
       hasAnyBlockPoolRegistered = true;
       isBlockTokenEnabled = keys.isBlockTokenEnabled();


### PR DESCRIPTION
Adds a new config `fs.block.access.token.migration.enabled` which allows us to migrate to block access tokens without downtime. Adds a test which verifies that it works as expected end-to-end for reads at least.