### PR TITLE
dont enable token auth method during migration mode

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
@@ -3196,7 +3196,7 @@ public abstract class Server {
         throw new IllegalArgumentException(AuthenticationMethod.TOKEN +
             " authentication requires a secret manager");
       } 
-    } else if (secretManager != null) {
+    } else if (secretManager != null && !isTokenMigrationModeEnabled(conf)) {
       LOG.debug(AuthenticationMethod.TOKEN +
           " authentication enabled for secret manager");
       // most preferred, go to the front of the line!
@@ -3206,6 +3206,10 @@ public abstract class Server {
     
     LOG.debug("Server accepts auth methods:" + authMethods);
     return authMethods;
+  }
+
+  private boolean isTokenMigrationModeEnabled(Configuration conf) {
+    return conf.getBoolean("dfs.block.access.token.migration.enabled", false);
   }
   
   private void closeConnection(Connection connection) {


### PR DESCRIPTION
Handles an edge case in our migration mode:

- Client requests LocatedBlocks from NameNode
- NameNode responds and includes block access tokens
- SaslRpcClient sees the tokens and forces SASL auth against DataNode
- Since DataNode is in migration mode, it did not register the block pool's tokens when it registered with NameNode. It returns with IllegalStateException
- SaslRpcClient does not handle that appropriately

This is not a problem for SaslDataTransferClient, which is what most of the hbase processes use. But specifically, when trying to read a file this is still open and being appended to, the DFSInputStream tries to get the visible length of the block. This call goes through SaslRpcClient instead of SaslDataTransferClient, and this is where we see the issue.

We work around it by not enabling AuthMethod.TOKEN when in migration mode. So when SaslRpcClient tries to connect with SASL to the DataNode, it responds with "i only support simple". The SaslRpcClient can then try again using simple, and all works.