### PR TITLE
New setting unsafe.dfs.encrypt.data.transfer.plaintext.fallback

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
@@ -1215,6 +1215,8 @@ public class DFSConfigKeys extends CommonConfigurationKeys {
 
   // Security-related configs
   public static final String DFS_ENCRYPT_DATA_TRANSFER_KEY = "dfs.encrypt.data.transfer";
+  public static final String UNSAFE_DFS_DATA_TRANSFER_PLAINTEXT_FALLBACK_KEY = "unsafe.dfs.encrypt.data.transfer.plaintext.fallback";
+  public static final boolean UNSAFE_DFS_DATA_TRANSFER_PLAINTEXT_FALLBACK_DEFAULT = false;
   public static final String DFS_ENCRYPT_DATA_OVERWRITE_DOWNSTREAM_DERIVED_QOP_KEY =
       "dfs.encrypt.data.overwrite.downstream.derived.qop";
   public static final boolean DFS_ENCRYPT_DATA_OVERWRITE_DOWNSTREAM_DERIVED_QOP_DEFAULT =

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DNConf.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DNConf.java
@@ -39,6 +39,8 @@ import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_DATANODE_PROCESS_COMMANDS
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_DATANODE_PROCESS_COMMANDS_THRESHOLD_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_ENCRYPT_DATA_OVERWRITE_DOWNSTREAM_DERIVED_QOP_DEFAULT;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_ENCRYPT_DATA_OVERWRITE_DOWNSTREAM_DERIVED_QOP_KEY;
+import static org.apache.hadoop.hdfs.DFSConfigKeys.UNSAFE_DFS_DATA_TRANSFER_PLAINTEXT_FALLBACK_DEFAULT;
+import static org.apache.hadoop.hdfs.DFSConfigKeys.UNSAFE_DFS_DATA_TRANSFER_PLAINTEXT_FALLBACK_KEY;
 import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.DFS_CLIENT_SOCKET_TIMEOUT_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_DATANODE_MAX_LOCKED_MEMORY_DEFAULT;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_DATANODE_MAX_LOCKED_MEMORY_KEY;
@@ -95,6 +97,7 @@ public class DNConf {
   final boolean dropCacheBehindReads;
   final boolean syncOnClose;
   final boolean encryptDataTransfer;
+  final boolean unsafeDataTransferPlaintextFallback;
   final boolean connectToDnViaHostname;
   final boolean overwriteDownstreamDerivedQOP;
   private final boolean pmemCacheRecoveryEnabled;
@@ -251,6 +254,7 @@ public class DNConf {
     this.encryptDataTransfer = getConf().getBoolean(
         DFS_ENCRYPT_DATA_TRANSFER_KEY,
         DFS_ENCRYPT_DATA_TRANSFER_DEFAULT);
+    this.unsafeDataTransferPlaintextFallback = getConf().getBoolean(UNSAFE_DFS_DATA_TRANSFER_PLAINTEXT_FALLBACK_KEY, UNSAFE_DFS_DATA_TRANSFER_PLAINTEXT_FALLBACK_DEFAULT);
     this.overwriteDownstreamDerivedQOP = getConf().getBoolean(
         DFS_ENCRYPT_DATA_OVERWRITE_DOWNSTREAM_DERIVED_QOP_KEY,
         DFS_ENCRYPT_DATA_OVERWRITE_DOWNSTREAM_DERIVED_QOP_DEFAULT);
@@ -325,6 +329,10 @@ public class DNConf {
    */
   public boolean getEncryptDataTransfer() {
     return encryptDataTransfer;
+  }
+
+  public boolean getUnsafeDataTransferPlaintextFallback() {
+    return unsafeDataTransferPlaintextFallback;
   }
 
   /**


### PR DESCRIPTION
In order to seamlessly enable `dfs.encrypt.data.transfer` on a running cluster, mixed encrypted and non-encrypted connections must be permitted for a period of time. As far as I can tell, the DataNode transfer protocol offers no way to do this currently. This PR provides this feature. When acting as a server, DataNodes with `dfs.encrypt.data.transfer` and `unsafe.dfs.encrypt.data.transfer.plaintext.fallback` enabled will attempt a SASL handshake, but if it fails, will assume that the connection is plaintext and accept it anyways.