### PR TITLE
Accept encrypted data transfer connections without making them

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
@@ -1215,6 +1215,9 @@ public class DFSConfigKeys extends CommonConfigurationKeys {
 
   // Security-related configs
   public static final String DFS_ENCRYPT_DATA_TRANSFER_KEY = "dfs.encrypt.data.transfer";
+
+  public static final String DFS_ACCEPT_ENCRYPTED_DATA_TRANSFER_KEY = "dfs.accepted.encrypted.data.transfer";
+  public static final boolean DFS_ACCEPT_ENCRYPTED_DATA_TRANSFER_DEFAULT = false;
   public static final String UNSAFE_DFS_DATA_TRANSFER_PLAINTEXT_FALLBACK_KEY = "unsafe.dfs.encrypt.data.transfer.plaintext.fallback";
   public static final boolean UNSAFE_DFS_DATA_TRANSFER_PLAINTEXT_FALLBACK_DEFAULT = false;
   public static final String DFS_ENCRYPT_DATA_OVERWRITE_DOWNSTREAM_DERIVED_QOP_KEY =

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/SaslDataTransferServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/SaslDataTransferServer.java
@@ -114,7 +114,7 @@ public class SaslDataTransferServer {
   public IOStreamPair receive(Peer peer, OutputStream underlyingOut,
       InputStream underlyingIn, int xferPort, DatanodeID datanodeId)
       throws IOException {
-    if (dnConf.getEncryptDataTransfer()) {
+    if (dnConf.getAcceptEncryptedDataTransfer()) {
       LOG.debug(
         "SASL server doing encrypted handshake for peer = {}, datanodeId = {}",
         peer, datanodeId);
@@ -389,7 +389,7 @@ public class SaslDataTransferServer {
         return new IOStreamPair(in, out);
       } else {
         throw new InvalidMagicNumberException(magicNumber,
-                dnConf.getEncryptDataTransfer());
+                dnConf.getAcceptEncryptedDataTransfer());
       }
     }
     try {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DNConf.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DNConf.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hdfs.server.datanode;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 
+import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_ACCEPT_ENCRYPTED_DATA_TRANSFER_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_BLOCKREPORT_INITIAL_DELAY_DEFAULT;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_BLOCKREPORT_INITIAL_DELAY_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_BLOCKREPORT_INTERVAL_MSEC_DEFAULT;
@@ -96,7 +97,8 @@ public class DNConf {
   final boolean syncBehindWritesInBackground;
   final boolean dropCacheBehindReads;
   final boolean syncOnClose;
-  final boolean encryptDataTransfer;
+  final boolean acceptEncryptedDataTransfer;
+  final boolean encryptDataTransferOutgoing;
   final boolean unsafeDataTransferPlaintextFallback;
   final boolean connectToDnViaHostname;
   final boolean overwriteDownstreamDerivedQOP;
@@ -250,10 +252,12 @@ public class DNConf {
     this.minimumNameNodeVersion = getConf().get(
         DFS_DATANODE_MIN_SUPPORTED_NAMENODE_VERSION_KEY,
         DFS_DATANODE_MIN_SUPPORTED_NAMENODE_VERSION_DEFAULT);
-    
-    this.encryptDataTransfer = getConf().getBoolean(
+
+    this.encryptDataTransferOutgoing = getConf().getBoolean(
         DFS_ENCRYPT_DATA_TRANSFER_KEY,
         DFS_ENCRYPT_DATA_TRANSFER_DEFAULT);
+    this.acceptEncryptedDataTransfer = getConf().getBoolean(DFS_ACCEPT_ENCRYPTED_DATA_TRANSFER_KEY,
+            getConf().getBoolean(DFS_ENCRYPT_DATA_TRANSFER_KEY, DFS_ENCRYPT_DATA_TRANSFER_DEFAULT));
     this.unsafeDataTransferPlaintextFallback = getConf().getBoolean(UNSAFE_DFS_DATA_TRANSFER_PLAINTEXT_FALLBACK_KEY, UNSAFE_DFS_DATA_TRANSFER_PLAINTEXT_FALLBACK_DEFAULT);
     this.overwriteDownstreamDerivedQOP = getConf().getBoolean(
         DFS_ENCRYPT_DATA_OVERWRITE_DOWNSTREAM_DERIVED_QOP_KEY,
@@ -327,8 +331,12 @@ public class DNConf {
    *
    * @return boolean true if encryption enabled for DataTransferProtocol
    */
-  public boolean getEncryptDataTransfer() {
-    return encryptDataTransfer;
+  public boolean getEncryptDataTransferOutgoing() {
+    return encryptDataTransferOutgoing;
+  }
+
+  public boolean getAcceptEncryptedDataTransfer() {
+    return acceptEncryptedDataTransfer;
   }
 
   public boolean getUnsafeDataTransferPlaintextFallback() {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
@@ -2675,7 +2675,7 @@ public class DataNode extends ReconfigurableBase
     return new DataEncryptionKeyFactory() {
       @Override
       public DataEncryptionKey newDataEncryptionKey() {
-        return dnConf.encryptDataTransfer ?
+        return dnConf.encryptDataTransferOutgoing ?
           blockPoolTokenSecretManager.generateDataEncryptionKey(
             block.getBlockPoolId()) : null;
       }


### PR DESCRIPTION
Follow up to https://github.com/HubSpot/hadoop/pull/21, which I'll fold into the same upstream ticket. This breaks out the setting for accepting encrypted connections and sending encrypted connections into two different settings, but falls back to using the original setting if the new one is not present. I should have seen this issue coming. DataNodes that get `dfs.encrypt.data.transfer` flipped on cannot start sending encryption connections right away, because some of their counterparts in the same cluster haven't had it flipped on yet.