### PR TITLE
Accept any QOP when using unsafe.dfs.encrypt.data.transfer.plaintext.fallback

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/DataTransferSaslUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/DataTransferSaslUtil.java
@@ -137,6 +137,18 @@ public final class DataTransferSaslUtil {
     return saslProps;
   }
 
+  public static Map<String, String> unsafeCreateSaslPropertiesForGeneralHandshake(
+          String encryptionAlgorithm) {
+    Map<String, String> saslProps = Maps.newHashMapWithExpectedSize(3);
+    saslProps.put(Sasl.QOP, String.format("%s,%s,%s",
+            QualityOfProtection.PRIVACY.getSaslQop(),
+            QualityOfProtection.INTEGRITY.getSaslQop(),
+            QualityOfProtection.AUTHENTICATION.getSaslQop()));
+    saslProps.put(Sasl.SERVER_AUTH, "true");
+    saslProps.put("com.sun.security.sasl.digest.cipher", encryptionAlgorithm);
+    return saslProps;
+  }
+
   /**
    * For an encrypted SASL negotiation, encodes an encryption key to a SASL
    * password.

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/SaslDataTransferServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/SaslDataTransferServer.java
@@ -302,9 +302,9 @@ public class SaslDataTransferServer {
       saslProps = saslPropsResolver.getServerProperties(
               getPeerAddress(peer));
     } else if (dnConf.getDataTransferAcceptSasl()) {
-      // This code path provides a way to accept encrypted connections even we don't make them.
+      // This code path provides a way to accept SASL connections even we don't make them.
       // dnConf.getSaslPropsResolver() is non-null only if dfs.data.transfer.protection is set.
-      saslProps = createSaslPropertiesForEncryption(dnConf.getEncryptionAlgorithm());
+      saslProps = unsafeCreateSaslPropertiesForGeneralHandshake(dnConf.getEncryptionAlgorithm());
     } else {
       saslProps = null;
     }


### PR DESCRIPTION
We've starting using `auth` QOP inside HBase clusters, thus we need to support more QOPs in this mode