### PR TITLE
Remove legacy RPM dependencies: chkconfig, service, and init-functions

### DIFF
--- a/rpm/hadoop.spec
+++ b/rpm/hadoop.spec
@@ -146,10 +146,10 @@ Source28: kms.default
 
 Buildroot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id} -u -n)
 
-Requires: coreutils, /usr/sbin/useradd, /usr/sbin/usermod, /sbin/chkconfig, /sbin/service
+Requires: coreutils, /usr/sbin/useradd, /usr/sbin/usermod
 Requires: psmisc, %{netcat_package}
 Requires: openssl-devel
-Requires: coreutils, /lib/lsb/init-functions
+Requires: coreutils
 
 # Sadly, Sun/Oracle JDK in RPM form doesn't provide libjvm.so, which means we have
 # to set AutoReq to no in order to minimize confusion. Not ideal, but seems to work.


### PR DESCRIPTION
These dependencies were for CentOS 6 service management. CentOS 8 had some shims for these so the install worked there despite these dependencies being unused by the package, but 9 does not so these dependencies need to be removed.