### PR TITLE
Add HubSpot specific Dispatcher changes

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/balancer/Dispatcher.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/balancer/Dispatcher.java
@@ -241,6 +241,7 @@ public class Dispatcher implements Closeable {
 
   /** This class keeps track of a scheduled reportedBlock move */
   public class PendingMove {
+    // HubSpot modification: We need to know if moves are done before shutting down.
     private final AtomicReference<MoveState> state = new AtomicReference<>(MoveState.PENDING);
     private DBlock reportedBlock;
     private Source source;
@@ -683,6 +684,7 @@ public class Dispatcher implements Closeable {
       return moveExecutor;
     }
 
+    // HubSpot Modification: We create our own DDataNodes, so we need to be able to shut them down
     public synchronized void shutdownMoveExecutor() {
       if (moveExecutor != null) {
         moveExecutor.shutdown();
@@ -1403,6 +1405,7 @@ public class Dispatcher implements Closeable {
     }
   }
 
+  // HubSpot modification: Perform the equivalent of reset() and then shutDown() when closing.
   @Override
   public void close() throws IOException {
     storageGroupMap.clear();


### PR DESCRIPTION
This restores several features to the Dispatcher that HubSpot is using:
- Status information for `PendingMove` objects.
- Better thread labeling.
- Makes the Dispatcher `Closeable`.
- Adds a public API for manipulating the move thread allocator lot size for invoking `executePendingMove` instead of `dispatchAndCheckContinue`.

This does not include the modification of adding `maxIterationTime` to `Source` objects because it's possible to set this at the Dispatcher level using a new constructor that was introduced since our internal fork version. That new constructor covers the use case we had.