### PR TITLE
Revert "Use emulated build containers"

### DIFF
--- a/rpm/rpm-amd64/.blazar.yaml
+++ b/rpm/rpm-amd64/.blazar.yaml
@@ -13,7 +13,7 @@ cache:
   - /root/.m2/repository
 
 env:
-  PLATFORMS: "arm64 amd64"
+  PLATFORMS: "amd64"
   DISABLE_CENTOS_6_RPMS: "true"
   ENABLE_CENTOS_8_RPMS: "true"
 
@@ -24,8 +24,8 @@ env:
   YUM_REPO_UPLOAD_OVERRIDE_CENTOS_8: "UPDATE ME"
 
   # The entry point script for the rpm build
-  RPM_BUILD_COMMAND: "./build.sh"
-  BUILD_CONTAINER_IMAGE_CENTOS_8: "docker.hubteam.com/apache-hadoop-build-container/apache-hadoop-build-container:latest"
+  RPM_BUILD_COMMAND: "../build.sh"
+  BUILD_CONTAINER_IMAGE_CENTOS_8: "docker.hubteam.com/apache-hadoop-build-container/hs-linux-darwin-toolchain-arm64/apache-hadoop-build-container:latest"
   CONTAINER_TEMP_OUTPUT_DIR: /temporary_artifacts
   CONTAINER_RPMS_OUTPUT_DIR: /generated_rpms
 

--- a/rpm/rpm-arm64/.blazar.yaml
+++ b/rpm/rpm-arm64/.blazar.yaml
@@ -1,0 +1,55 @@
+buildType: ARM64
+
+buildpack:
+  name: Blazar-Buildpack-RPM
+
+provides:
+  - name: hadoop-rpm
+
+depends:
+  - name: apache-hadoop-build-container
+
+# unlike normal maven builds, we want to use our own m2 because the build process involves
+# mvn install. we don't want these installed jars to mess up the global m2 cache.
+cache:
+  - /root/.m2/repository
+
+env:
+  PLATFORMS: "arm64"
+  DISABLE_CENTOS_6_RPMS: "true"
+  ENABLE_CENTOS_8_RPMS: "true"
+
+  MAIN_BRANCH: "hubspot-3.3"
+  MAIN_YUM_REPO: "8_hs-hadoop"
+  DEVELOP_YUM_REPO: "8_hs-hadoop-develop"
+  # This will be updated automatically by the "Set yum repo and package version" step below
+  YUM_REPO_UPLOAD_OVERRIDE_CENTOS_8: "UPDATE ME"
+
+  # The entry point script for the rpm build
+  RPM_BUILD_COMMAND: "../build.sh"
+  BUILD_CONTAINER_IMAGE_CENTOS_8: "docker.hubteam.com/apache-hadoop-build-container/apache-hadoop-build-container:latest"
+  CONTAINER_TEMP_OUTPUT_DIR: /temporary_artifacts
+  CONTAINER_RPMS_OUTPUT_DIR: /generated_rpms
+
+before:
+  - description: Set yum repo
+    commands:
+      - |
+          if [ "$GIT_BRANCH" = "$MAIN_BRANCH" ]; then
+            repo=$MAIN_YUM_REPO
+          else
+            repo=$DEVELOP_YUM_REPO
+          fi
+          # exports in this rc file are available in all steps
+          echo "export YUM_REPO_UPLOAD_OVERRIDE_CENTOS_8=$repo" >> $BUILD_COMMAND_RC_FILE
+          echo "Will upload package to $repo"
+
+buildResources:
+  cpus: 8
+  memoryMb: 16384
+
+stepActivation:
+  uploadRpms:
+    branchRegexes: ['.*']
+
+buildTimeoutOverrideMinutes: 180


### PR DESCRIPTION
Reverts HubSpot/hadoop#29. Build system was changed to add back support for the ARM64 build type. Builds are much faster that way, so we prefer that.