### PR TITLE
Update build configuration to not require write to RC file

### DIFF
--- a/rpm/rpm-amd64/.blazar.yaml
+++ b/rpm/rpm-amd64/.blazar.yaml
@@ -16,7 +16,7 @@ env:
   PLATFORMS: "amd64"
   DISABLE_CENTOS_6_RPMS: "true"
   ENABLE_CENTOS_8_RPMS: "true"
-  YUM_REPO_UPLOAD_OVERRIDE_CENTOS_8: "${8_hs-hadoop}${GIT_NON_DEFAULT_BRANCH:+-develop}"
+  YUM_REPO_UPLOAD_OVERRIDE_CENTOS_8: "8_hs-hadoop${GIT_NON_DEFAULT_BRANCH:+-develop}"
 
   # The entry point script for the rpm build
   RPM_BUILD_COMMAND: "../build.sh"

--- a/rpm/rpm-amd64/.blazar.yaml
+++ b/rpm/rpm-amd64/.blazar.yaml
@@ -16,12 +16,7 @@ env:
   PLATFORMS: "amd64"
   DISABLE_CENTOS_6_RPMS: "true"
   ENABLE_CENTOS_8_RPMS: "true"
-
-  MAIN_BRANCH: "hubspot-3.3"
-  MAIN_YUM_REPO: "8_hs-hadoop"
-  DEVELOP_YUM_REPO: "8_hs-hadoop-develop"
-  # This will be updated automatically by the "Set yum repo and package version" step below
-  YUM_REPO_UPLOAD_OVERRIDE_CENTOS_8: "UPDATE ME"
+  YUM_REPO_UPLOAD_OVERRIDE_CENTOS_8: "${8_hs-hadoop}${GIT_NON_DEFAULT_BRANCH:+-develop}"
 
   # The entry point script for the rpm build
   RPM_BUILD_COMMAND: "../build.sh"
@@ -32,15 +27,7 @@ env:
 before:
   - description: Set yum repo
     commands:
-      - |
-          if [ "$GIT_BRANCH" = "$MAIN_BRANCH" ]; then
-            repo=$MAIN_YUM_REPO
-          else
-            repo=$DEVELOP_YUM_REPO
-          fi
-          # exports in this rc file are available in all steps
-          echo "export YUM_REPO_UPLOAD_OVERRIDE_CENTOS_8=$repo" >> $BUILD_COMMAND_RC_FILE
-          echo "Will upload package to $repo"
+      - echo "Will upload package to $YUM_REPO_UPLOAD_OVERRIDE_CENTOS_8"
 
 buildResources:
   cpus: 8

--- a/rpm/rpm-arm64/.blazar.yaml
+++ b/rpm/rpm-arm64/.blazar.yaml
@@ -19,9 +19,7 @@ env:
   DISABLE_CENTOS_6_RPMS: "true"
   ENABLE_CENTOS_8_RPMS: "true"
 
-  MAIN_YUM_REPO: "8_hs-hadoop"
-  DEVELOP_YUM_REPO: "8_hs-hadoop-develop"
-  YUM_REPO_UPLOAD_OVERRIDE_CENTOS_8: "${8_hs-hadoop}${GIT_NON_DEFAULT_BRANCH:+-develop}"
+  YUM_REPO_UPLOAD_OVERRIDE_CENTOS_8: "8_hs-hadoop${GIT_NON_DEFAULT_BRANCH:+-develop}"
 
   # The entry point script for the rpm build
   RPM_BUILD_COMMAND: "../build.sh"

--- a/rpm/rpm-arm64/.blazar.yaml
+++ b/rpm/rpm-arm64/.blazar.yaml
@@ -19,11 +19,9 @@ env:
   DISABLE_CENTOS_6_RPMS: "true"
   ENABLE_CENTOS_8_RPMS: "true"
 
-  MAIN_BRANCH: "hubspot-3.3"
   MAIN_YUM_REPO: "8_hs-hadoop"
   DEVELOP_YUM_REPO: "8_hs-hadoop-develop"
-  # This will be updated automatically by the "Set yum repo and package version" step below
-  YUM_REPO_UPLOAD_OVERRIDE_CENTOS_8: "UPDATE ME"
+  YUM_REPO_UPLOAD_OVERRIDE_CENTOS_8: "${8_hs-hadoop}${GIT_NON_DEFAULT_BRANCH:+-develop}"
 
   # The entry point script for the rpm build
   RPM_BUILD_COMMAND: "../build.sh"
@@ -34,15 +32,7 @@ env:
 before:
   - description: Set yum repo
     commands:
-      - |
-          if [ "$GIT_BRANCH" = "$MAIN_BRANCH" ]; then
-            repo=$MAIN_YUM_REPO
-          else
-            repo=$DEVELOP_YUM_REPO
-          fi
-          # exports in this rc file are available in all steps
-          echo "export YUM_REPO_UPLOAD_OVERRIDE_CENTOS_8=$repo" >> $BUILD_COMMAND_RC_FILE
-          echo "Will upload package to $repo"
+      - echo "Will upload package to $YUM_REPO_UPLOAD_OVERRIDE_CENTOS_8"
 
 buildResources:
   cpus: 8


### PR DESCRIPTION
We're cleaning up usages of the RC file from `.blazar.yamls`. `GIT_NON_DEFAULT_BRANCH` is defined when a build is run on a non-default Github branch so we're able to just add `-develop` to the suffix of the YUM repo when on a feature branch if that non default branch env variable is defined. 

@charlesconnell 