### PR TITLE
build with Intel ISA-L codec for EC

### DIFF
--- a/rpm/rpm-amd64/.blazar.yaml
+++ b/rpm/rpm-amd64/.blazar.yaml
@@ -22,7 +22,7 @@ env:
 
   # The entry point script for the rpm build
   RPM_BUILD_COMMAND: "../build.sh"
-  BUILD_CONTAINER_IMAGE_CENTOS_8: "docker.hubteam.com/apache-hadoop-build-container/hs-linux-darwin-toolchain-arm64/apache-hadoop-build-container:latest"
+  BUILD_CONTAINER_IMAGE_CENTOS_8: "docker.hubteam.com/apache-hadoop-build-container/apache-hadoop-build-container:latest"
   CONTAINER_TEMP_OUTPUT_DIR: /temporary_artifacts
   CONTAINER_RPMS_OUTPUT_DIR: /generated_rpms
 

--- a/rpm/sources/do-component-build
+++ b/rpm/sources/do-component-build
@@ -22,6 +22,7 @@ mkdir -p build
 MAVEN_OPTS+="-DskipTests -DskipTest -DskipITs -Dmaven.javadoc.skip=true "
 MAVEN_OPTS+="-Drequire.zstd -Dbundle.zstd -Dzstd.lib=/usr/lib64 "
 MAVEN_OPTS+="-Drequire.snappy -Dbundle.snappy=true -Dsnappy.lib=/usr/lib64 "
+MAVEN_OPTS+="-Drequire.isal -Dbundle.isal=true -Disal.lib=/usr/lib64 "
 MAVEN_OPTS+="-Drequire.openssl "
 
 # The Yarn UI and the yarn applications catalog both require a version of node.js which does not work with centos6

--- a/rpm/sources/install_hadoop.sh
+++ b/rpm/sources/install_hadoop.sh
@@ -180,7 +180,7 @@ cp ${BUILD_DIR}/include/hdfs.h ${SYSTEM_INCLUDE_DIR}/
 cp -r ${BUILD_DIR}/include/hdfspp ${SYSTEM_INCLUDE_DIR}/
 
 cp ${BUILD_DIR}/lib/native/*.a ${HADOOP_NATIVE_LIB_DIR}/
-for library in `cd ${BUILD_DIR}/lib/native ; ls libsnappy.so.1.* 2>/dev/null` libhadoop.so.1.0.0 libnativetask.so.1.0.0; do
+for library in `cd ${BUILD_DIR}/lib/native ; ls libsnappy.so.1.* 2>/dev/null` libisal.so.2 libhadoop.so.1.0.0 libnativetask.so.1.0.0 ; do
   cp ${BUILD_DIR}/lib/native/${library} ${HADOOP_NATIVE_LIB_DIR}/
   ldconfig -vlN ${HADOOP_NATIVE_LIB_DIR}/${library}
   ln -s ${library} ${HADOOP_NATIVE_LIB_DIR}/${library/.so.*/}.so


### PR DESCRIPTION
Fixes our build image which was pinned to a branch build. The master build now has libisal.so.2 available. With that we can enable the mvn properties to require and bundle isal. We also have to fix our install script to copy the lib into the right spot. I tested this with `hadoop checknative`