### PR TITLE
Fix build after enabling sources

### DIFF
--- a/.blazar.yaml
+++ b/.blazar.yaml
@@ -5,7 +5,7 @@ buildpack:
 # be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
 # throughout a build
 env:
-  MAVEN_ARGS: ""
+  MAVEN_ARGS: "-Dassembly.skipAssembly=true"
   SET_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""

--- a/.blazar.yaml
+++ b/.blazar.yaml
@@ -5,7 +5,7 @@ buildpack:
 # be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
 # throughout a build
 env:
-  MAVEN_ARGS: "-pl !hadoop-tools/hadoop-benchmark"
+  MAVEN_ARGS: "-pl !hadoop-tools/hadoop-benchmark -DdeployAtEnd=true"
   SET_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""

--- a/.blazar.yaml
+++ b/.blazar.yaml
@@ -5,7 +5,7 @@ buildpack:
 # be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
 # throughout a build
 env:
-  MAVEN_ARGS: "-Dassembly.skipAssembly=true"
+  MAVEN_ARGS: "-pl !hadoop-tools/hadoop-benchmark"
   SET_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""

--- a/build-scripts/prepare_environment.sh
+++ b/build-scripts/prepare_environment.sh
@@ -21,7 +21,7 @@ MAIN_BRANCH="hubspot-${PATCH_VERSION}"
 # At some point it would be good to more closely link this to our hadoop build, but that can only happen
 # once we update our apache-hadoop build to do a full maven. At which point we can probably change this to
 # like 3.0-hubspot-SNAPSHOT and leave it at that.
-MAVEN_ARGS="$VERSION_ARGS -Dgpg.skip=true -DskipTests=true -DskipTest -DskipITs  -Dmaven.install.skip=false -Dmaven.repo.local=$WORKSPACE/.m2"
+MAVEN_ARGS="$MAVEN_AGS $VERSION_ARGS -Dgpg.skip=true -DskipTests=true -DskipTest -DskipITs  -Dmaven.install.skip=false -Dmaven.repo.local=$WORKSPACE/.m2"
 
 MAVEN_ARGS="$MAVEN_ARGS -Phbase1"
 

--- a/build-scripts/prepare_environment.sh
+++ b/build-scripts/prepare_environment.sh
@@ -21,7 +21,7 @@ MAIN_BRANCH="hubspot-${PATCH_VERSION}"
 # At some point it would be good to more closely link this to our hadoop build, but that can only happen
 # once we update our apache-hadoop build to do a full maven. At which point we can probably change this to
 # like 3.0-hubspot-SNAPSHOT and leave it at that.
-MAVEN_ARGS="$MAVEN_AGS $VERSION_ARGS -Dgpg.skip=true -DskipTests=true -DskipTest -DskipITs  -Dmaven.install.skip=false -Dmaven.repo.local=$WORKSPACE/.m2"
+MAVEN_ARGS="$MAVEN_ARGS $VERSION_ARGS -Dgpg.skip=true -DskipTests=true -DskipTest -DskipITs  -Dmaven.install.skip=false -Dmaven.repo.local=$WORKSPACE/.m2"
 
 MAVEN_ARGS="$MAVEN_ARGS -Phbase1"
 


### PR DESCRIPTION
For some reason we started failing to build hadoop-benchmark after the last PR to enable source generation. I couldn't figure it out, and we don't need this module, so it's easy enough to skip. At the same time I'm adding a new -DdeployAtEnd flag which we recently uncovered. As the name suggests, it'll deploy all of the built modules to nexus at the end of the build. This is better because it's less likely for people to get partial updates if a build fails partway through or takes a long time.