### PR TITLE
Remove deployAtEnd because it disables publishing

### DIFF
--- a/.blazar.yaml
+++ b/.blazar.yaml
@@ -17,3 +17,5 @@ before:
   - description: "Prepare build environment"
     commands:
       - $WORKSPACE/build-scripts/prepare_environment.sh
+
+buildTimeoutOverrideMinutes: 60

--- a/.blazar.yaml
+++ b/.blazar.yaml
@@ -5,7 +5,7 @@ buildpack:
 # be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
 # throughout a build
 env:
-  MAVEN_ARGS: "-pl !hadoop-tools/hadoop-benchmark -DdeployAtEnd=true"
+  MAVEN_ARGS: "-pl !hadoop-tools/hadoop-benchmark"
   SET_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""


### PR DESCRIPTION
## Problem
` -DdeployAtEnd=true` actually prevents packages from being correctly published to Nexus.

## Solution
Remove it. This goes back to a previously known build configuration, but retains the build exclusion from the original commit: https://github.com/HubSpot/hadoop/pull/39

## Testing
Verified new versions of the package are available in Nexus.