### PR TITLE
Configurably use WeakReferencedElasticByteBufferPool in DFSStripedInputStream

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSClient.java
@@ -167,9 +167,12 @@ import org.apache.hadoop.hdfs.server.datanode.CachingStrategy;
 import org.apache.hadoop.hdfs.server.namenode.SafeModeException;
 import org.apache.hadoop.hdfs.server.protocol.DatanodeStorageReport;
 import org.apache.hadoop.hdfs.util.IOUtilsClient;
+import org.apache.hadoop.io.ByteBufferPool;
+import org.apache.hadoop.io.ElasticByteBufferPool;
 import org.apache.hadoop.io.EnumSetWritable;
 import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.io.Text;
+import org.apache.hadoop.io.WeakReferencedElasticByteBufferPool;
 import org.apache.hadoop.io.retry.LossyRetryInvocationHandler;
 import org.apache.hadoop.ipc.RPC;
 import org.apache.hadoop.ipc.RemoteException;
@@ -244,6 +247,7 @@ public class DFSClient implements java.io.Closeable, RemotePeerFactory,
       new DFSHedgedReadMetrics();
   private static ThreadPoolExecutor HEDGED_READ_THREAD_POOL;
   private static volatile ThreadPoolExecutor STRIPED_READ_THREAD_POOL;
+  private static volatile ByteBufferPool STRIPED_READ_BUFFER_POOL;
   private final int smallBufferSize;
   private final long serverDefaultsValidityPeriod;
 
@@ -413,6 +417,8 @@ public class DFSClient implements java.io.Closeable, RemotePeerFactory,
 
     this.initThreadsNumForStripedReads(dfsClientConf.
         getStripedReadThreadpoolSize());
+    this.initBufferPoolForStripedReads(dfsClientConf.
+        getStripedReadWeakRefBufferPool());
     this.saslClient = new SaslDataTransferClient(
         conf, DataTransferSaslUtil.getSaslPropertiesResolver(conf),
         TrustedChannelResolver.getInstance(conf), nnFallbackToSimpleAuth);
@@ -3112,12 +3118,31 @@ public class DFSClient implements java.io.Closeable, RemotePeerFactory,
     }
   }
 
+  private void initBufferPoolForStripedReads(boolean useWeakReference) {
+    if (STRIPED_READ_BUFFER_POOL != null) {
+      return;
+    }
+    synchronized (DFSClient.class) {
+      if (STRIPED_READ_BUFFER_POOL == null) {
+        if (useWeakReference) {
+          STRIPED_READ_BUFFER_POOL = new WeakReferencedElasticByteBufferPool();
+        } else {
+          STRIPED_READ_BUFFER_POOL = new ElasticByteBufferPool();
+        }
+      }
+    }
+  }
+
   ThreadPoolExecutor getHedgedReadsThreadPool() {
     return HEDGED_READ_THREAD_POOL;
   }
 
   ThreadPoolExecutor getStripedReadsThreadPool() {
     return STRIPED_READ_THREAD_POOL;
+  }
+
+  ByteBufferPool getStripedReadBufferPool() {
+    return STRIPED_READ_BUFFER_POOL;
   }
 
   boolean isHedgedReadsEnabled() {

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSStripedInputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSStripedInputStream.java
@@ -34,7 +34,6 @@ import org.apache.hadoop.hdfs.util.StripedBlockUtil.AlignedStripe;
 import org.apache.hadoop.hdfs.util.StripedBlockUtil.StripeRange;
 import org.apache.hadoop.io.ByteBufferPool;
 
-import org.apache.hadoop.io.ElasticByteBufferPool;
 import org.apache.hadoop.io.erasurecode.CodecUtil;
 import org.apache.hadoop.hdfs.protocol.ErasureCodingPolicy;
 
@@ -62,7 +61,6 @@ import static org.apache.hadoop.hdfs.util.IOUtilsClient.updateReadStatistics;
 @InterfaceAudience.Private
 public class DFSStripedInputStream extends DFSInputStream {
 
-  private static final ByteBufferPool BUFFER_POOL = new ElasticByteBufferPool();
   private final BlockReaderInfo[] blockReaders;
   private final int cellSize;
   private final short dataBlkNum;
@@ -121,7 +119,7 @@ public class DFSStripedInputStream extends DFSInputStream {
 
   private void resetCurStripeBuffer(boolean shouldAllocateBuf) {
     if (shouldAllocateBuf && curStripeBuf == null) {
-      curStripeBuf = BUFFER_POOL.getBuffer(useDirectBuffer(),
+      curStripeBuf = getBufferPool().getBuffer(useDirectBuffer(),
           cellSize * dataBlkNum);
     }
     if (curStripeBuf != null) {
@@ -132,7 +130,7 @@ public class DFSStripedInputStream extends DFSInputStream {
 
   protected synchronized ByteBuffer getParityBuffer() {
     if (parityBuf == null) {
-      parityBuf = BUFFER_POOL.getBuffer(useDirectBuffer(),
+      parityBuf = getBufferPool().getBuffer(useDirectBuffer(),
           cellSize * parityBlkNum);
     }
     parityBuf.clear();
@@ -144,7 +142,7 @@ public class DFSStripedInputStream extends DFSInputStream {
   }
 
   protected ByteBufferPool getBufferPool() {
-    return BUFFER_POOL;
+    return dfsClient.getStripedReadBufferPool();
   }
 
   protected ThreadPoolExecutor getStripedReadsThreadPool(){
@@ -180,11 +178,11 @@ public class DFSStripedInputStream extends DFSInputStream {
       super.close();
     } finally {
       if (curStripeBuf != null) {
-        BUFFER_POOL.putBuffer(curStripeBuf);
+        getBufferPool().putBuffer(curStripeBuf);
         curStripeBuf = null;
       }
       if (parityBuf != null) {
-        BUFFER_POOL.putBuffer(parityBuf);
+        getBufferPool().putBuffer(parityBuf);
         parityBuf = null;
       }
       if (decoder != null) {
@@ -560,11 +558,11 @@ public class DFSStripedInputStream extends DFSInputStream {
   public synchronized void unbuffer() {
     super.unbuffer();
     if (curStripeBuf != null) {
-      BUFFER_POOL.putBuffer(curStripeBuf);
+      getBufferPool().putBuffer(curStripeBuf);
       curStripeBuf = null;
     }
     if (parityBuf != null) {
-      BUFFER_POOL.putBuffer(parityBuf);
+      getBufferPool().putBuffer(parityBuf);
       parityBuf = null;
     }
   }

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/HdfsClientConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/HdfsClientConfigKeys.java
@@ -507,6 +507,9 @@ public interface HdfsClientConfigKeys {
     String DATANODE_MAX_ATTEMPTS = PREFIX +
                                    "datanode.max.attempts";
     int DATANODE_MAX_ATTEMPTS_DEFAULT = 1;
+
+    String WEAK_REF_BUFFER_POOL_KEY = "bufferpool.weak.references.enabled";
+    boolean WEAK_REF_BUFFER_POOL_DEFAULT = false;
   }
 
   /** dfs.http.client configuration properties */

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/HdfsClientConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/HdfsClientConfigKeys.java
@@ -508,7 +508,7 @@ public interface HdfsClientConfigKeys {
                                    "datanode.max.attempts";
     int DATANODE_MAX_ATTEMPTS_DEFAULT = 1;
 
-    String WEAK_REF_BUFFER_POOL_KEY = "bufferpool.weak.references.enabled";
+    String WEAK_REF_BUFFER_POOL_KEY = PREFIX + "bufferpool.weak.references.enabled";
     boolean WEAK_REF_BUFFER_POOL_DEFAULT = false;
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/impl/DfsClientConf.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/impl/DfsClientConf.java
@@ -155,6 +155,7 @@ public class DfsClientConf {
       replicaAccessorBuilderClasses;
 
   private final int stripedReadThreadpoolSize;
+  private final boolean stripedReadWeakRefBufferPool;
 
   private final boolean dataTransferTcpNoDelay;
 
@@ -289,6 +290,11 @@ public class DfsClientConf {
     Preconditions.checkArgument(stripedReadThreadpoolSize > 0, "The value of " +
         HdfsClientConfigKeys.StripedRead.THREADPOOL_SIZE_KEY +
         " must be greater than 0.");
+
+    stripedReadWeakRefBufferPool = conf.getBoolean(
+            HdfsClientConfigKeys.StripedRead.WEAK_REF_BUFFER_POOL_KEY,
+            HdfsClientConfigKeys.StripedRead.WEAK_REF_BUFFER_POOL_DEFAULT);
+
     replicaAccessorBuilderClasses = loadReplicaAccessorBuilderClasses(conf);
 
     leaseHardLimitPeriod =
@@ -678,6 +684,10 @@ public class DfsClientConf {
    */
   public int getStripedReadThreadpoolSize() {
     return stripedReadThreadpoolSize;
+  }
+
+  public boolean getStripedReadWeakRefBufferPool() {
+    return stripedReadWeakRefBufferPool;
   }
 
   /**


### PR DESCRIPTION
To be upstreamed in https://issues.apache.org/jira/browse/HDFS-17364. Patch has been submitted.

Tested this overnight on a production regionserver and it reduces the used heap by about 1.5GB and results in better GC performance.