### PR TITLE
Update Maven deploy plugin to fix deployAtEnd issue

### DIFF
--- a/.blazar.yaml
+++ b/.blazar.yaml
@@ -5,7 +5,7 @@ buildpack:
 # be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
 # throughout a build
 env:
-  MAVEN_BUILD_ARGS: "-pl !hadoop-tools/hadoop-benchmark"
+  MAVEN_BUILD_ARGS: "-pl !hadoop-tools/hadoop-benchmark -DdeployAtEnd=true -Dmaven-deploy-plugin.version=3.1.1"
   SET_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""


### PR DESCRIPTION
## Problem
`deployAtEnd` is desirable for our build system because it keeps the produced libraries consistent for a commit, reducing the risk of out of sync components caused by partial builds. However, due to the use of this configuration in the pom.xml files, the original Maven deploy plugin version does not actually deploy the built artifacts:

```xml
      <plugin>
        <artifactId>maven-deploy-plugin</artifactId>
        <configuration>
          <skip>true</skip>
        </configuration>
      </plugin>
```

## Solution
Upgrade the version of maven-deploy-plugin in use from `2.8.1` to `3.1.1`.  This behavior was fixed in Maven Deploy Plugin 3.1.0 ([MDEPLOY-226](https://issues.apache.org/jira/browse/MDEPLOY-226)).

## Testing
This build used the updated version of the deploy plugin: https://private.hubteam.com/blazar/branches/10108237/builds/6/modules/hadoop

It correctly deployed during the invocation of the last module. I also verified the artifact could be downloaded from Nexus.

## Working changes
- Change build order to avoid deploy plugin defect
- Remove build exclusion
- Restore original location for argument, remove weird skip config
- Move the deployAtEnd to a different spot