### PR TITLE
Handle direct file copy correctly for S3 use cases

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/CopyFromLocalOperation.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/CopyFromLocalOperation.java
@@ -356,13 +356,9 @@ public class CopyFromLocalOperation extends ExecutingStoreOperation<Void> {
   private Path getFinalPath(Path src) throws PathIOException {
     URI currentSrcUri = src.toUri();
     URI relativeSrcUri = source.toUri().relativize(currentSrcUri);
-    if (relativeSrcUri.equals(currentSrcUri)) {
-      throw new PathIOException("Cannot get relative path for URI:"
-          + relativeSrcUri);
-    }
 
     Optional<FileStatus> status = getDestStatus();
-    if (!relativeSrcUri.getPath().isEmpty()) {
+    if (!relativeSrcUri.getPath().isEmpty() && !relativeSrcUri.equals(currentSrcUri)) {
       return new Path(destination, relativeSrcUri.getPath());
     } else if (status.isPresent() && status.get().isDirectory()) {
       // file to dir


### PR DESCRIPTION
## Problem
[HADOOP-18173](https://issues.apache.org/jira/browse/HADOOP-18173) affects Hadoop 3.3.6. Rather than copying our JARs as one directory in ThinJarUtils, we copy them one at time, and this fails when copying to S3.

## Solution
Tweak the logic. In the case of a single file, the `currentSrcUri` is the path itself. When the specified source is a directory, it doesn't compare against itself because of the calling logic: https://github.com/HubSpot/hadoop/blob/442ae9d40178d49d84b1f86faadc598eadaf8bb7/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/CopyFromLocalOperation.java#L217-L220

All directories bypass the `getFinalPath` method, meaning that it can actually be assumed that `src` is not a directory. `source` is a class member that in most cases is a directory, but not always (as described in the above bug report and in our own usage). In the case that `source` and `src` are the same item, we actually want to follow to the last two cases where either the destination is a directory (as is the case for our own `ThinJarUtils`) or the destination is a file to replace.

## Testing
This was tested while setting up a YARN cluster in our environment using S3 for the filesystem.

## Next steps
I would like to upstream this change, but I don't want to delay Vinay's project while we figure that out.