### PR TITLE
Build into AnyLinuxVersion repos for future-proofing

### DIFF
--- a/rpm/.blazar.yaml
+++ b/rpm/.blazar.yaml
@@ -29,9 +29,9 @@ before:
     commands:
       - |
           if [[ "$GIT_NON_DEFAULT_BRANCH" = "" || "$GIT_NON_DEFAULT_BRANCH" = "hubspot-3.3.6" ]]; then
-            REPO_NAME="8_hs-hadoop"
+            REPO_NAME="AnyLinuxVersion_hs-hadoop"
           else
-            REPO_NAME="8_hs-hadoop-develop"
+            REPO_NAME="AnyLinuxVersion_hs-hadoop-develop"
           fi
           echo "Will upload package to $REPO_NAME"
           write-build-env-var REPO_NAME "$REPO_NAME"


### PR DESCRIPTION
We now have the AnyLinuxVersion repos for RPMs that don't need to be different per Linux version. Let's put future builds of Hadoop in there.