### PR TITLE
Adds a post copy files hook for configuring the job

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/DefaultPostResourceJobHook.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/DefaultPostResourceJobHook.java
@@ -1,0 +1,8 @@
+package org.apache.hadoop.mapreduce;
+
+public class DefaultPostResourceJobHook implements PostResourceJobHook {
+  @Override
+  public void updateConfiguration(Job job) {
+
+  }
+}

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/JobSubmitter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/JobSubmitter.java
@@ -193,6 +193,9 @@ class JobSubmitter {
 
       copyAndConfigureFiles(job, submitJobDir);
 
+      Class<? extends PostResourceJobHook> postResourceHook = conf.getClass("post.resource.job.hook", DefaultPostResourceJobHook.class, PostResourceJobHook.class);
+      ReflectionUtils.newInstance(postResourceHook, conf).updateConfiguration(job);
+
       Path submitJobFile = JobSubmissionFiles.getJobConfPath(submitJobDir);
       
       // Create the splits for the job

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/PostResourceJobHook.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/PostResourceJobHook.java
@@ -1,0 +1,5 @@
+package org.apache.hadoop.mapreduce;
+
+public interface PostResourceJobHook {
+  void updateConfiguration(Job job);
+}


### PR DESCRIPTION
This adds a client-side hook for configuring the job post-resource submission.
This would be needed to allow for performant local job submissions without
requiring to ship a specialized file system to the yarn containers.

I can also instead implement  this using a java `Consumer` interface to make
this a runtime optimization.

## NOTICE

Please create an issue in ASF JIRA before opening a pull request,
and you need to set the title of the pull request which starts with
the corresponding JIRA issue number. (e.g. HADOOP-XXXXX. Fix a typo in YYY.)
For more details, please see https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
