### PR TITLE
Remove Timestamp Check for S3

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -1501,17 +1501,17 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
   @Override
   public Path makeQualified(final Path path) {
     Path q = super.makeQualified(path);
-    if (!q.isRoot()) {
-      String urlString = q.toUri().toString();
-      if (urlString.endsWith(Path.SEPARATOR)) {
-        // this is a path which needs root stripping off to avoid
-        // confusion, See HADOOP-15430
-        LOG.debug("Stripping trailing '/' from {}", q);
-        // deal with an empty "/" at the end by mapping to the parent and
-        // creating a new path from it
-        q = new Path(urlString.substring(0, urlString.length() - 1));
-      }
-    }
+//    if (!q.isRoot()) {
+//      String urlString = q.toUri().toString();
+//      if (urlString.endsWith(Path.SEPARATOR)) {
+//        // this is a path which needs root stripping off to avoid
+//        // confusion, See HADOOP-15430
+//        LOG.debug("Stripping trailing '/' from {}", q);
+//        // deal with an empty "/" at the end by mapping to the parent and
+//        // creating a new path from it
+//        q = new Path(urlString.substring(0, urlString.length() - 1));
+//      }
+//    }
     if (!q.isRoot() && q.getName().isEmpty()) {
       q = q.getParent();
     }
@@ -3720,7 +3720,7 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
       final String key,
       final Set<StatusProbeEnum> probes,
       final boolean needEmptyDirectoryFlag) throws IOException {
-    LOG.debug("S3GetFileStatus {}", path);
+    LOG.info("S3GetFileStatus {}", path);
     // either you aren't looking for the directory flag, or you are,
     // and if you are, the probe list must contain list.
     Preconditions.checkArgument(!needEmptyDirectoryFlag
@@ -3736,8 +3736,9 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
       try {
         // look for the simple file
         ObjectMetadata meta = getObjectMetadata(key);
-        LOG.debug("Found exact file: normal file {}", key);
+        LOG.info("Found exact file: normal file {}", key);
         long contentLength = meta.getContentLength();
+        LOG.info("contentLength {}", contentLength);
         // check if CSE is enabled, then strip padded length.
         if (isCSEEnabled
             && meta.getUserMetaDataOf(Headers.CRYPTO_CEK_ALGORITHM) != null
@@ -3757,6 +3758,7 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
         // But: an empty bucket is also a 404, so check for that
         // and fail.
         if (e.getStatusCode() != SC_404 || isUnknownBucket(e)) {
+          LOG.info("e.getStatusCode() in S3a filesystem : ",e.getStatusCode());
           throw translateException("getFileStatus", path, e);
         }
       } catch (AmazonClientException e) {

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -1501,17 +1501,17 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
   @Override
   public Path makeQualified(final Path path) {
     Path q = super.makeQualified(path);
-//    if (!q.isRoot()) {
-//      String urlString = q.toUri().toString();
-//      if (urlString.endsWith(Path.SEPARATOR)) {
-//        // this is a path which needs root stripping off to avoid
-//        // confusion, See HADOOP-15430
-//        LOG.debug("Stripping trailing '/' from {}", q);
-//        // deal with an empty "/" at the end by mapping to the parent and
-//        // creating a new path from it
-//        q = new Path(urlString.substring(0, urlString.length() - 1));
-//      }
-//    }
+    if (!q.isRoot()) {
+      String urlString = q.toUri().toString();
+      if (urlString.endsWith(Path.SEPARATOR)) {
+        // this is a path which needs root stripping off to avoid
+        // confusion, See HADOOP-15430
+        LOG.debug("Stripping trailing '/' from {}", q);
+        // deal with an empty "/" at the end by mapping to the parent and
+        // creating a new path from it
+        q = new Path(urlString.substring(0, urlString.length() - 1));
+      }
+    }
     if (!q.isRoot() && q.getName().isEmpty()) {
       q = q.getParent();
     }
@@ -3720,7 +3720,7 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
       final String key,
       final Set<StatusProbeEnum> probes,
       final boolean needEmptyDirectoryFlag) throws IOException {
-    LOG.info("S3GetFileStatus {}", path);
+    LOG.debug("S3GetFileStatus {}", path);
     // either you aren't looking for the directory flag, or you are,
     // and if you are, the probe list must contain list.
     Preconditions.checkArgument(!needEmptyDirectoryFlag
@@ -3736,9 +3736,8 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
       try {
         // look for the simple file
         ObjectMetadata meta = getObjectMetadata(key);
-        LOG.info("Found exact file: normal file {}", key);
+        LOG.debug("Found exact file: normal file {}", key);
         long contentLength = meta.getContentLength();
-        LOG.info("contentLength {}", contentLength);
         // check if CSE is enabled, then strip padded length.
         if (isCSEEnabled
             && meta.getUserMetaDataOf(Headers.CRYPTO_CEK_ALGORITHM) != null
@@ -3758,7 +3757,6 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
         // But: an empty bucket is also a 404, so check for that
         // and fail.
         if (e.getStatusCode() != SC_404 || isUnknownBucket(e)) {
-          LOG.info("e.getStatusCode() in S3a filesystem : ",e.getStatusCode());
           throw translateException("getFileStatus", path, e);
         }
       } catch (AmazonClientException e) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/FSDownload.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/FSDownload.java
@@ -61,6 +61,7 @@ import org.apache.hadoop.thirdparty.com.google.common.cache.LoadingCache;
 import org.apache.hadoop.thirdparty.com.google.common.util.concurrent.Futures;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 
+import static org.apache.hadoop.fs.FileSystem.FS_DEFAULT_NAME_KEY;
 import static org.apache.hadoop.fs.Options.OpenFileOptions.FS_OPTION_OPENFILE_READ_POLICY;
 import static org.apache.hadoop.fs.Options.OpenFileOptions.FS_OPTION_OPENFILE_READ_POLICY_WHOLE_FILE;
 import static org.apache.hadoop.util.functional.FutureIO.awaitFuture;
@@ -275,7 +276,9 @@ public class FSDownload implements Callable<Path> {
     FileSystem sourceFs = sCopy.getFileSystem(conf);
     FileStatus sStat = sourceFs.getFileStatus(sCopy);
     if (sStat.getModificationTime() != resource.getTimestamp()) {
-      if(!Strings.isNullOrEmpty(conf.get("hubspot.hadoop.file.system.type")) && conf.get("hubspot.hadoop.file.system.type").equalsIgnoreCase("S3")){
+      //if the hadoop file system used is s3 then we skip the timestamp check.
+      if(conf.get(FS_DEFAULT_NAME_KEY) != null &&
+          conf.get(FS_DEFAULT_NAME_KEY).startsWith("s3a://")){
         LOG.info("Resource " + sCopy + " changed on src filesystem" +
             " - expected: " +
             "\"" + Times.formatISO8601(resource.getTimestamp()) + "\"" +

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/FSDownload.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/FSDownload.java
@@ -32,6 +32,7 @@ import java.util.regex.Pattern;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import org.apache.hadoop.thirdparty.com.google.common.base.Strings;
 import org.apache.hadoop.util.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -274,7 +275,7 @@ public class FSDownload implements Callable<Path> {
     FileSystem sourceFs = sCopy.getFileSystem(conf);
     FileStatus sStat = sourceFs.getFileStatus(sCopy);
     if (sStat.getModificationTime() != resource.getTimestamp()) {
-      if(conf.get("hubspot.hadoop.file.system.type").equalsIgnoreCase("S3")){
+      if(!Strings.isNullOrEmpty(conf.get("hubspot.hadoop.file.system.type")) && conf.get("hubspot.hadoop.file.system.type").equalsIgnoreCase("S3")){
         LOG.info("Resource " + sCopy + " changed on src filesystem" +
             " - expected: " +
             "\"" + Times.formatISO8601(resource.getTimestamp()) + "\"" +

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/FSDownload.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/FSDownload.java
@@ -274,12 +274,18 @@ public class FSDownload implements Callable<Path> {
     FileSystem sourceFs = sCopy.getFileSystem(conf);
     FileStatus sStat = sourceFs.getFileStatus(sCopy);
     if (sStat.getModificationTime() != resource.getTimestamp()) {
-      throw new IOException("Resource " + sCopy + " changed on src filesystem" +
+      LOG.info("Resource " + sCopy + " changed on src filesystem" +
           " - expected: " +
           "\"" + Times.formatISO8601(resource.getTimestamp()) + "\"" +
           ", was: " +
           "\"" + Times.formatISO8601(sStat.getModificationTime()) + "\"" +
           ", current time: " + "\"" + Times.formatISO8601(Time.now()) + "\"");
+//      throw new IOException("Resource " + sCopy + " changed on src filesystem" +
+//          " - expected: " +
+//          "\"" + Times.formatISO8601(resource.getTimestamp()) + "\"" +
+//          ", was: " +
+//          "\"" + Times.formatISO8601(sStat.getModificationTime()) + "\"" +
+//          ", current time: " + "\"" + Times.formatISO8601(Time.now()) + "\"");
     }
     if (resource.getVisibility() == LocalResourceVisibility.PUBLIC) {
       if (!isPublic(sourceFs, sCopy, sStat, statCache)) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/FSDownload.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/FSDownload.java
@@ -274,18 +274,21 @@ public class FSDownload implements Callable<Path> {
     FileSystem sourceFs = sCopy.getFileSystem(conf);
     FileStatus sStat = sourceFs.getFileStatus(sCopy);
     if (sStat.getModificationTime() != resource.getTimestamp()) {
-      LOG.info("Resource " + sCopy + " changed on src filesystem" +
-          " - expected: " +
-          "\"" + Times.formatISO8601(resource.getTimestamp()) + "\"" +
-          ", was: " +
-          "\"" + Times.formatISO8601(sStat.getModificationTime()) + "\"" +
-          ", current time: " + "\"" + Times.formatISO8601(Time.now()) + "\"");
-//      throw new IOException("Resource " + sCopy + " changed on src filesystem" +
-//          " - expected: " +
-//          "\"" + Times.formatISO8601(resource.getTimestamp()) + "\"" +
-//          ", was: " +
-//          "\"" + Times.formatISO8601(sStat.getModificationTime()) + "\"" +
-//          ", current time: " + "\"" + Times.formatISO8601(Time.now()) + "\"");
+      if(conf.get("hubspot.hadoop.file.system.type").equalsIgnoreCase("S3")){
+        LOG.info("Resource " + sCopy + " changed on src filesystem" +
+            " - expected: " +
+            "\"" + Times.formatISO8601(resource.getTimestamp()) + "\"" +
+            ", was: " +
+            "\"" + Times.formatISO8601(sStat.getModificationTime()) + "\"" +
+            ", current time: " + "\"" + Times.formatISO8601(Time.now()) + "\"");
+      }else {
+        throw new IOException("Resource " + sCopy + " changed on src filesystem" +
+            " - expected: " +
+            "\"" + Times.formatISO8601(resource.getTimestamp()) + "\"" +
+            ", was: " +
+            "\"" + Times.formatISO8601(sStat.getModificationTime()) + "\"" +
+            ", current time: " + "\"" + Times.formatISO8601(Time.now()) + "\"");
+      }
     }
     if (resource.getVisibility() == LocalResourceVisibility.PUBLIC) {
       if (!isPublic(sourceFs, sCopy, sStat, statCache)) {


### PR DESCRIPTION
When using s3 as Hadoop File system we enconter resource changed on src file system error. The reason I think is that in S3 implementation file timestamps are changed which does not happen in HDFS. [Timestamp doc](https://hadoop.apache.org/docs/current//hadoop-project-dist/hadoop-common/FileSystemShell.html#Timestamps)

Tested this by deploying this branch in QA NA. The same jobs that failed with this error passed after this change. 


Example error log

```
Application application_1722669525346_0001 failed 5 times due to AM Container for appattempt_1722669525346_0001_000005 exited with exitCode: -1000
Failing this attempt.Diagnostics: [2024-08-05 14:41:43.796]Resource s3a://hubspot-hadoop-fs-backfill-s3-h3-eu1-qa/mapred/staging/backfill-s3-h3-qa/Wkd60q0QYAePuklPUXszbRFkLCjyB03P/.staging/job_1722669525346_0001/libjars changed on src filesystem - expected: "2024-08-05T14:39:39.188+0000", was: "2024-08-05T14:41:43.775+0000", current time: "2024-08-05T14:41:43.775+0000"
java.io.IOException: Resource s3a://hubspot-hadoop-fs-backfill-s3-h3-eu1-qa/mapred/staging/backfill-s3-h3-qa/Wkd60q0QYAePuklPUXszbRFkLCjyB03P/.staging/job_1722669525346_0001/libjars changed on src filesystem - expected: "2024-08-05T14:39:39.188+0000", was: "2024-08-05T14:41:43.775+0000", current time: "2024-08-05T14:41:43.775+0000"
at org.apache.hadoop.yarn.util.FSDownload.verifyAndCopy(FSDownload.java:282)
at org.apache.hadoop.yarn.util.FSDownload.access$000(FSDownload.java:72)
at org.apache.hadoop.yarn.util.FSDownload$2.run(FSDownload.java:425)
at org.apache.hadoop.yarn.util.FSDownload$2.run(FSDownload.java:422)
```
