### PR TITLE
Remove tracking URL log line

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/Job.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/Job.java
@@ -20,15 +20,15 @@ package org.apache.hadoop.mapreduce;
 
 import java.io.IOException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.security.PrivilegedExceptionAction;
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.apache.hadoop.classification.InterfaceAudience;
-import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.classification.InterfaceAudience.Private;
+import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.classification.InterfaceStability.Unstable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.Configuration.IntegerRanges;
@@ -40,10 +40,10 @@ import org.apache.hadoop.mapreduce.filecache.DistributedCache;
 import org.apache.hadoop.mapreduce.protocol.ClientProtocol;
 import org.apache.hadoop.mapreduce.task.JobContextImpl;
 import org.apache.hadoop.mapreduce.util.ConfigUtil;
+import org.apache.hadoop.thirdparty.com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.util.StringUtils;
 import org.apache.hadoop.yarn.api.records.ReservationId;
-
-import org.apache.hadoop.thirdparty.com.google.common.annotations.VisibleForTesting;
+import org.apache.http.client.utils.URIBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -1673,13 +1673,25 @@ public class Job extends JobContextImpl implements JobContext, AutoCloseable {
     final JobSubmitter submitter = 
         getJobSubmitter(cluster.getFileSystem(), cluster.getClient());
     status = ugi.doAs(new PrivilegedExceptionAction<JobStatus>() {
-      public JobStatus run() throws IOException, InterruptedException, 
+      public JobStatus run() throws IOException, InterruptedException,
       ClassNotFoundException {
         return submitter.submitJobInternal(Job.this, cluster);
       }
     });
     state = JobState.RUNNING;
-    LOG.info("The url to track the job: " + getTrackingURL());
+    LOG.info("The url to track the job: {}", getAdjustedTrackingUrl());
+   }
+
+  /**
+   * Adjust the tracking URL to conform with YARN sidecar proxy changes.
+   * @return Corrected YARN URL
+   */
+   private String getAdjustedTrackingUrl() {
+    try {
+      return new URIBuilder(getTrackingURL()).setScheme("https").setPort(-1).build().toString();
+    } catch (URISyntaxException e) {
+      return getTrackingURL();
+    }
    }
   
   /**

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/Job.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/Job.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.mapreduce;
 
 import java.io.IOException;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.security.PrivilegedExceptionAction;
 import java.util.Collection;
 import java.util.LinkedHashMap;
@@ -43,7 +42,6 @@ import org.apache.hadoop.mapreduce.util.ConfigUtil;
 import org.apache.hadoop.thirdparty.com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.util.StringUtils;
 import org.apache.hadoop.yarn.api.records.ReservationId;
-import org.apache.http.client.utils.URIBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -1679,19 +1677,6 @@ public class Job extends JobContextImpl implements JobContext, AutoCloseable {
       }
     });
     state = JobState.RUNNING;
-    LOG.info("The url to track the job: {}", getAdjustedTrackingUrl());
-   }
-
-  /**
-   * Adjust the tracking URL to conform with YARN sidecar proxy changes.
-   * @return Corrected YARN URL
-   */
-   private String getAdjustedTrackingUrl() {
-    try {
-      return new URIBuilder(getTrackingURL()).setScheme("https").setPort(-1).build().toString();
-    } catch (URISyntaxException e) {
-      return getTrackingURL();
-    }
    }
   
   /**


### PR DESCRIPTION
## Description

Remove the YARN URL logged in `Job`.

It's currently inaccurate due to our proxy sidecar changes. We also handle logging this URL elsewhere after adjusting the tracking URL, so it feels unnecessary to do it multiple times.

Tested via branch deploy:
<img width="1598" alt="logRemoved" src="https://github.com/user-attachments/assets/452d3fae-0f86-43e6-8aa3-929cc9a98297" />