### PR TITLE
Fix Hadoop Build

### DIFF
--- a/.blazar.yaml
+++ b/.blazar.yaml
@@ -5,7 +5,7 @@ buildpack:
 # be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
 # throughout a build
 env:
-  MAVEN_BUILD_ARGS: "-pl !hadoop-tools/hadoop-benchmark -DdeployAtEnd=true -Dmaven-deploy-plugin.version=3.1.1"
+  MAVEN_BUILD_ARGS: "-pl !hadoop-tools/hadoop-benchmark -DdeployAtEnd=true -Dmaven-deploy-plugin.version=3.1.1 -DdisableGE"
   SET_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""

--- a/.blazar.yaml
+++ b/.blazar.yaml
@@ -5,13 +5,14 @@ buildpack:
 # be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
 # throughout a build
 env:
-  MAVEN_BUILD_ARGS: "-pl !hadoop-tools/hadoop-benchmark -DdeployAtEnd=true -Dmaven-deploy-plugin.version=3.1.1 -DdisableGE"
+  MAVEN_BUILD_ARGS: "-pl !hadoop-tools/hadoop-benchmark -DdeployAtEnd=true -Dmaven-deploy-plugin.version=3.1.1"
   SET_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""
   # Hadoop build needs -Pdist to generate sources, but that fails on javadoc generation. When we have time to figure out why javadoc generation
   # is failing, that would probably be best. For now I've manually added the source plugin to the executions here which seems to work. 
   MAVEN_PHASE: "org.apache.maven.plugins:maven-source-plugin:2.3:jar-no-fork org.apache.maven.plugins:maven-source-plugin:2.3:test-jar-no-fork package deploy"
+  GE_ENABLED: false
 
 before:
   - description: "Prepare build environment"

--- a/.blazar.yaml
+++ b/.blazar.yaml
@@ -1,6 +1,5 @@
 buildpack:
   name: Blazar-Buildpack-Java-single-module
-  branch: js-ge-enabled
 
 # The build environment requires environment variables to be explicitly defined before they may
 # be modified by the `write-build-env-var` utilty script to persist changes to an environment variable

--- a/.blazar.yaml
+++ b/.blazar.yaml
@@ -1,5 +1,6 @@
 buildpack:
   name: Blazar-Buildpack-Java-single-module
+  branch: js-ge-enabled
 
 # The build environment requires environment variables to be explicitly defined before they may
 # be modified by the `write-build-env-var` utilty script to persist changes to an environment variable


### PR DESCRIPTION
## Problem
Due to a change in our tooling, our Hadoop build has started failing.

## Solution
This new configuration makes the Hadoop build work correctly again. I'll wait for a passing build before continuing. You can see from the history that it worked using Jared's buildpack update.