### PR TITLE
Improve logging for slow HDFS reads/writes

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSInputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSInputStream.java
@@ -1197,7 +1197,7 @@ public class DFSInputStream extends FSInputStream
         long readTimeMS = Time.monotonicNow() - beginReadMS;
         if (readTimeMS > dfsClient.getConf().getSlowIoWarningThresholdMs()) {
           DFSClient.LOG.info("Slow HDFS read: datanode={} duration_ms={} block={} src={}",
-              datanode.info.getXferAddr(), readTimeMS, block.getBlock(), src);
+              datanode.info.getHostName(), readTimeMS, block.getBlock(), src);
         }
         buf.position(buf.position() + nread);
 

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSInputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSInputStream.java
@@ -1186,12 +1186,18 @@ public class DFSInputStream extends FSInputStream
         tmp = tmp.slice();
         int nread = 0;
         int ret;
+        long beginReadMS = Time.monotonicNow();
         while (true) {
           ret = reader.read(tmp);
           if (ret <= 0) {
             break;
           }
           nread += ret;
+        }
+        long readTimeMS = Time.monotonicNow() - beginReadMS;
+        if (readTimeMS > dfsClient.getConf().getSlowIoWarningThresholdMs()) {
+          DFSClient.LOG.info("Slow HDFS read: datanode={} duration_ms={} block={} src={}",
+              datanode.info.getXferAddr(), readTimeMS, block.getBlock(), src);
         }
         buf.position(buf.position() + nread);
 

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DataStreamer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DataStreamer.java
@@ -1150,10 +1150,20 @@ class DataStreamer extends Daemon {
               //     + " took " + duration + "ms (threshold="
               //     + dfsclientSlowLogThresholdMs + "ms); ack: " + ack
               //     + ", targets: " + Arrays.asList(targets));
-              for (DatanodeInfo dn : targets) {
-                LOG.info("Slow HDFS write: datanode={} duration_ms={} block={}",
-                    dn.getXferAddr(), duration, block.getCurrentBlock());
-              }
+              // the ack contains the time dn1 spent waiting for its downstream (dn2+dn3 combined).
+              // we use this to estimate which node was slowest: compare dn1's time against the
+              // average downstream per-node time, and log whichever is higher.
+              long downstreamPipelineDurationMs = ack.getDownstreamAckTimeNanos() / 1_000_000;
+              long headDatanodeDurationMs = duration - downstreamPipelineDurationMs;
+              long downstreamDatanodeCount = targets.length - 1;
+              long downstreamPerNodeDurationMs = downstreamDatanodeCount > 0
+                  ? downstreamPipelineDurationMs / downstreamDatanodeCount : 0;
+              DatanodeInfo likelySlowestDatanode = headDatanodeDurationMs >= downstreamPerNodeDurationMs
+                  ? targets[0] : targets[1];
+              long likelySlowestDurationMs = headDatanodeDurationMs >= downstreamPerNodeDurationMs
+                  ? headDatanodeDurationMs : downstreamPerNodeDurationMs;
+              LOG.info("Slow HDFS write: datanode={} duration_ms={} block={}",
+                  likelySlowestDatanode.getHostName(), likelySlowestDurationMs, block.getCurrentBlock());
             }
           }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DataStreamer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DataStreamer.java
@@ -1143,13 +1143,16 @@ class DataStreamer extends Daemon {
           ack.readFields(blockReplyStream);
           if (ack.getSeqno() != DFSPacket.HEART_BEAT_SEQNO) {
             Long begin = packetSendTime.get(ack.getSeqno());
-            if (begin != null) {
-              long duration = Time.monotonicNow() - begin;
-              if (duration > dfsclientSlowLogThresholdMs) {
-                LOG.info("Slow ReadProcessor read fields for block " + block
-                    + " took " + duration + "ms (threshold="
-                    + dfsclientSlowLogThresholdMs + "ms); ack: " + ack
-                    + ", targets: " + Arrays.asList(targets));
+            long duration = begin != null ? Time.monotonicNow() - begin : -1L;
+            if (duration > 0 && duration > dfsclientSlowLogThresholdMs) {
+              // Replaced by per-datanode structured log below for consistency with read path slow logs.
+              // LOG.info("Slow ReadProcessor read fields for block " + block
+              //     + " took " + duration + "ms (threshold="
+              //     + dfsclientSlowLogThresholdMs + "ms); ack: " + ack
+              //     + ", targets: " + Arrays.asList(targets));
+              for (DatanodeInfo dn : targets) {
+                LOG.info("Slow HDFS write: datanode={} duration_ms={} block={}",
+                    dn.getXferAddr(), duration, block.getCurrentBlock());
               }
             }
           }

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/StripeReader.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/StripeReader.java
@@ -307,9 +307,16 @@ abstract class StripeReader {
       }
 
       int ret = 0;
+      long beginReadMS = Time.monotonicNow();
       for (ByteBufferStrategy strategy : strategies) {
         int bytesReead = readToBuffer(reader, datanode, strategy, currentBlock, chunkIndex);
         ret += bytesReead;
+      }
+      long readTimeMS = Time.monotonicNow() - beginReadMS;
+      if (readTimeMS > dfsStripedInputStream.getDFSClient().getConf().getSlowIoWarningThresholdMs()) {
+        DFSClient.LOG.info("Slow HDFS ec-read: datanode={} duration_ms={} block={} src={}",
+            datanode.getXferAddr(), readTimeMS, currentBlock,
+            dfsStripedInputStream.getSrc());
       }
       return new BlockReadStats(ret, reader.isShortCircuit(),
           reader.getNetworkDistance());

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/StripeReader.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/StripeReader.java
@@ -315,7 +315,7 @@ abstract class StripeReader {
       long readTimeMS = Time.monotonicNow() - beginReadMS;
       if (readTimeMS > dfsStripedInputStream.getDFSClient().getConf().getSlowIoWarningThresholdMs()) {
         DFSClient.LOG.info("Slow HDFS ec-read: datanode={} duration_ms={} block={} src={}",
-            datanode.getXferAddr(), readTimeMS, currentBlock,
+            datanode.getHostName(), readTimeMS, currentBlock,
             dfsStripedInputStream.getSrc());
       }
       return new BlockReadStats(ret, reader.isShortCircuit(),


### PR DESCRIPTION
We recently ran into an issue with slow HDFS reads, and were blind as to which node was the culprit because logging didn't contain enough information. This adds three log lines, read, write, and erasure-coded read, with a standardized format and best-effort detection for which datanode was the culprit