### PR TITLE
HubSpot Edit: move block token computation outside of FSNamesystemLock in getBlockLocations() path

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
@@ -1590,6 +1590,40 @@ public class BlockManager implements BlockStatsMXBean {
     }
   }
 
+  /**
+   * Generate block tokens for every block in the given {@link LocatedBlocks}.
+   *
+   * <p>This is intended to be called <em>after</em> the FSNamesystem lock has
+   * been released. Block token generation computes an HMAC per block (and one
+   * per internal block for striped/erasure-coded files); this is pure CPU work
+   * that reads only the immutable {@link LocatedBlock} snapshot and the
+   * (independently synchronized) block token secret manager, so it does not
+   * require the namesystem lock. Doing it under the read lock only lengthens
+   * the critical section and increases lock contention, so callers on hot read
+   * paths (e.g. {@code getBlockLocations}) build the locations under the lock
+   * and defer token generation to this method once the lock is dropped.
+   *
+   * @see #setBlockToken(LocatedBlock, AccessMode)
+   */
+  public void setBlockTokens(LocatedBlocks blocks, AccessMode mode)
+      throws IOException {
+    if (!isBlockTokenEnabled() || blocks == null) {
+      return;
+    }
+    List<LocatedBlock> locatedBlocks = blocks.getLocatedBlocks();
+    if (locatedBlocks != null) {
+      for (LocatedBlock lb : locatedBlocks) {
+        setBlockToken(lb, mode);
+      }
+    }
+    // The last block is tracked separately from the main list and, when
+    // present, is a distinct LocatedBlock instance that also needs a token.
+    LocatedBlock lastBlock = blocks.getLastLocatedBlock();
+    if (lastBlock != null) {
+      setBlockToken(lastBlock, mode);
+    }
+  }
+
   void addKeyUpdateCommand(final List<DatanodeCommand> cmds,
       final DatanodeDescriptor nodeinfo) {
     // check access key update

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -2121,8 +2121,14 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
       readLock();
       try {
         checkOperation(OperationCategory.READ);
+        // Build the located blocks under the lock, but do NOT generate block
+        // tokens here. Token generation is an HMAC-per-block computation (one
+        // per internal block for striped files) that does not need the
+        // namesystem lock; generating it under the lock only lengthens the
+        // read-lock critical section and drives lock contention. Tokens are
+        // generated after the lock is released (see setBlockTokens below).
         res = FSDirStatAndListingOp.getBlockLocations(
-            dir, pc, srcArg, offset, length, true);
+            dir, pc, srcArg, offset, length, false);
         inode = res.getIIp().getLastINode();
         if (isInSafeMode()) {
           for (LocatedBlock b : res.blocks.getLocatedBlocks()) {
@@ -2179,6 +2185,12 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
         LOG.warn("Failed to update the access time of " + src, e);
       }
     }
+
+    // Generate block tokens now that the namesystem lock has been released,
+    // keeping the per-block HMAC computation out of the read-lock critical
+    // section (see BlockManager#setBlockTokens).
+    blockManager.setBlockTokens(res.blocks,
+        BlockTokenIdentifier.AccessMode.READ);
 
     LocatedBlocks blocks = res.blocks;
     sortLocatedBlocks(clientMachine, blocks);


### PR DESCRIPTION
Computing block tokens is the most computationally expensive part of a NameNode's job when under the load typical of a HubSpot HBase cluster. This is especially true for cluster using erasure coding. See the attached CPU-time profile of a busy NameNode. This is a problem because this computation is done while the FSNamesystemLock read lock is held. At Hubspot, busy NameNodes see their IPC handler threads spend almost their entire lives waiting for the FSNamesystemLock read lock. The full mechanism that causes lock contention to start is not yet understood. However, reducing the time threads spend under the lock can only help the situation.

This PR passes the unit tests `TestBlockToken`, ` TestBlockTokenWithDFS`, `TestBlockTokenWithDFSStriped`


[namenode-erebus-hb2-a-0.cpu.html](https://github.com/user-attachments/files/30513442/namenode-erebus-hb2-a-0.cpu.html)
