### PR TITLE
HubSpot Edit: Restore default LZO buffer size used to write our LZO HFiles

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
+++ b/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
@@ -929,7 +929,7 @@
 
 <property>
   <name>io.compression.codec.lzo.buffersize</name>
-  <value>65536</value>
+  <value>262144</value>
   <description>
     Internal buffer size for Lzo compressor/decompressors.
   </description>


### PR DESCRIPTION
LZO assumes that blocks compressed using a certain buffer size will be decompressed using a buffer at least as large. Decompressing with a smaller buffer causes the decompressed bytes to overflow the buffer and corrupt your memory! Hadoop 3.4 introduced the default in `hdfs-default.xml` that is fine in isolation, but was not safe to apply to an existing installation.